### PR TITLE
feat: Use SHA1 hash for workflow ID generation

### DIFF
--- a/src/app/canvas/page.tsx
+++ b/src/app/canvas/page.tsx
@@ -11,6 +11,7 @@ import styles from '@/app/canvas/assets/PlateeRAG.module.scss';
 import { executeWorkflow, saveWorkflow, listWorkflows } from '@/app/api/workflowAPI';
 import { getWorkflowName, getWorkflowState, saveWorkflowState, ensureValidWorkflowState, saveWorkflowName, startNewWorkflow } from '@/app/(common)/components/workflowStorage';
 import { devLog } from '@/app/utils/logger';
+import { generateSha1Hash } from '../utils/generateSha1Hash';
 
 export default function CanvasPage() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -295,7 +296,8 @@ export default function CanvasPage() {
 
         let canvasState = (canvasRef.current as any).getCanvasState();
         const workflowName = getWorkflowName();
-        const workflowId = `workflow_${Date.now()}`;
+
+        const workflowId = `workflow_${generateSha1Hash(workflowName)}`;
         canvasState['id'] = workflowId;
         
         devLog.log('Canvas state before save:', canvasState);

--- a/src/app/utils/generateSha1Hash.ts
+++ b/src/app/utils/generateSha1Hash.ts
@@ -1,0 +1,11 @@
+import { BinaryLike, createHash } from "crypto";
+
+export function generateSha1Hash(data: BinaryLike) {
+    const hash = createHash('sha1');
+
+    hash.update(data);
+
+    const hexHash = hash.digest('hex');
+
+    return hexHash;
+}


### PR DESCRIPTION
Replace timestamp-based workflow ID with a SHA1 hash of the workflow name to ensure consistent and unique identifiers across sessions. This improves workflow tracking and avoids potential collisions from relying on timestamps.