### PR TITLE
[리팩토링] 채팅 컴포넌트 통합 및 모드별 인터페이스 일원화

### DIFF
--- a/src/app/chat/components/ChatArea.tsx
+++ b/src/app/chat/components/ChatArea.tsx
@@ -1,0 +1,99 @@
+import { FiClock } from 'react-icons/fi';
+import styles from '@/app/chat/assets/ChatInterface.module.scss';
+import { MessageList } from './MessageList';
+import { EmptyState } from './EmptyState';
+import { IOLog, Workflow } from './types';
+
+interface ChatAreaProps {
+    mode: "existing" | "new-workflow" | "new-default";
+    loading: boolean;
+    ioLogs: IOLog[];
+    workflow: Workflow;
+    executing: boolean;
+    setInputMessage: (message: string) => void;
+    messagesRef: React.RefObject<HTMLDivElement | null>;
+    pendingLogId: string | null;
+    renderMessageContent: (content: string, isUserMessage?: boolean) => React.ReactNode;
+    formatDate: (dateString: string) => string;
+}
+
+export const ChatArea: React.FC<ChatAreaProps> = ({
+    mode,
+    loading,
+    ioLogs,
+    workflow,
+    executing,
+    setInputMessage,
+    messagesRef,
+    pendingLogId,
+    renderMessageContent,
+    formatDate,
+}) => {
+    // 1. 로딩 상태 처리 (existing 모드 전용)
+    if (mode === 'existing' && loading) {
+        return (
+            <div className={styles.chatContainer}>
+                <div className={styles.loadingState}>
+                    <div className={styles.loadingSpinner}></div>
+                    <p>채팅 기록을 불러오는 중...</p>
+                </div>
+            </div>
+        );
+    }
+
+    // 2. 각 모드에 맞는 컨텐츠 렌더링
+    const renderContent = () => {
+        if (mode === 'existing') {
+            return ioLogs.length === 0 ? (
+                <EmptyState title="대화 기록이 없습니다">
+                    <p>&quot;{workflow.name}&quot; 워크플로우의 이전 대화를 불러올 수 없습니다.</p>
+                    <p>새로운 대화를 시작해보세요.</p>
+                </EmptyState>
+            ) : (
+                <MessageList
+                    ioLogs={ioLogs}
+                    pendingLogId={pendingLogId}
+                    executing={executing}
+                    renderMessageContent={renderMessageContent}
+                    formatDate={formatDate}
+                />
+            );
+        }
+
+        if (mode === 'new-workflow') {
+            return (
+                <EmptyState
+                    title="첫 대화를 시작해보세요!"
+                    showSuggestions
+                    onChipClick={setInputMessage}
+                    disabled={executing}
+                >
+                    <p>&quot;{workflow.name}&quot; 워크플로우가 준비되었습니다.</p>
+                </EmptyState>
+            );
+        }
+
+        if (mode === 'new-default') {
+            return (
+                <EmptyState
+                    title="첫 대화를 시작해보세요!"
+                    showSuggestions
+                    onChipClick={setInputMessage}
+                    disabled={executing}
+                >
+                    <p>일반 채팅 모드로 자유롭게 대화할 수 있습니다.</p>
+                </EmptyState>
+            );
+        }
+        
+        return null; // 예외 케이스
+    };
+
+    return (
+        <div className={styles.chatContainer}>
+            <div ref={messagesRef} className={styles.messagesArea}>
+                {renderContent()}
+            </div>
+        </div>
+    );
+};

--- a/src/app/chat/components/ChatContent.tsx
+++ b/src/app/chat/components/ChatContent.tsx
@@ -5,8 +5,6 @@ import { LuWorkflow } from "react-icons/lu";
 import { IoChatbubblesOutline } from "react-icons/io5";
 import WorkflowSelection from './WorkflowSelection';
 import ChatInterface from './ChatInterface';
-import NewChatInterface from './NewChatInterface';
-import DefaultChatInterface from './DefaultChatInterface';
 
 interface ChatContentProps {
     onChatStarted?: () => void; // 채팅 시작 후 호출될 콜백
@@ -49,57 +47,46 @@ const ChatContentInner: React.FC<ChatContentProps> = ({ onChatStarted }) => {
 
     const handleWorkflowSelect = (workflow: any) => {
         setSelectedWorkflow(workflow);
-        // 새로운 채팅으로 시작 (항상 NewChatInterface 사용)
         setCurrentView('newChat');
     };
 
     const handleDefaultChatStart = () => {
+        setSelectedWorkflow({
+            id: 'default_mode',
+            name: 'default_mode',
+            filename: 'default_chat',
+            author: 'System',
+            nodeCount: 1,
+            status: 'active' as const,
+        });
         setCurrentView('defaultChat');
     };
 
-    // 일반 채팅 화면 (DefaultChatInterface)
-    if (currentView === 'defaultChat') {
-        return (
-            <div className={styles.chatContainer}>
-                <div className={styles.workflowSection}>
-                    <DefaultChatInterface 
-                        onBack={() => setCurrentView('welcome')}
-                        onChatStarted={onChatStarted}
-                    />
-                </div>
-            </div>
-        );
-    }
+    const getChatMode = () => {
+        if (currentView === 'existingChat' && selectedWorkflow) return 'existing';
+        if (currentView === 'newChat'&& selectedWorkflow) return 'new-workflow';
+        if (currentView === 'defaultChat') return 'new-default';
+        return null;
+    };
 
-    // 새로운 채팅 화면 (NewChatInterface)
-    if (currentView === 'newChat' && selectedWorkflow) {
-        return (
-            <div className={styles.chatContainer}>
-                <div className={styles.workflowSection}>
-                    <NewChatInterface 
-                        workflow={selectedWorkflow}
-                        onBack={() => setCurrentView('workflow')}
-                        onChatStarted={onChatStarted}
-                    />
-                </div>
-            </div>
-        );
-    }
+    const chatMode = getChatMode();
 
-    // 기존 채팅 화면 (ChatInterface)
-    if (currentView === 'existingChat' && selectedWorkflow) {
+    if (chatMode) {
         return (
-            <div className={styles.chatContainer}>
-                <div className={styles.workflowSection}>
-                    <ChatInterface 
-                        workflow={selectedWorkflow}
-                        existingChatData={existingChatData}
-                        onBack={() => setCurrentView('workflow')}
-                    />
-                </div>
+            <div className="h-full">
+            {chatMode && (
+                <ChatInterface
+                    key={chatMode === 'existing' ? existingChatData?.interactionId : chatMode}
+                    mode={chatMode}
+                    workflow={selectedWorkflow}
+                    existingChatData={chatMode === 'existing' ? existingChatData : undefined}
+                    onChatStarted={chatMode === 'existing' ? undefined : onChatStarted}
+                    onBack={currentView === 'defaultChat' ? () => setCurrentView('welcome') : () => setCurrentView('workflow')}
+                />
+            )}
             </div>
         );
-    }
+    };
 
     // 워크플로우 선택 화면
     if (currentView === 'workflow') {

--- a/src/app/chat/components/ChatHeader.tsx
+++ b/src/app/chat/components/ChatHeader.tsx
@@ -1,0 +1,49 @@
+import { FiArrowLeft, FiMessageSquare } from 'react-icons/fi';
+import styles from '@/app/chat/assets/ChatInterface.module.scss';
+import { ChatHeaderProps } from './types';
+
+const ChatHeader: React.FC<ChatHeaderProps> = ({ mode, workflow, ioLogs, onBack, hideBackButton }) => {
+    let title = '';
+    let subtitle = '';
+    let chatCountText = '';
+
+    const isExistingMode = mode === 'existing';
+
+    if (isExistingMode) {
+        title = workflow.name === 'default_mode' ? '일반 채팅' : workflow.name;
+        subtitle = hideBackButton ? '현재 채팅을 계속하세요' : '기존 대화를 계속하세요';
+        chatCountText = `${ioLogs.length}개의 대화`;
+    } else if (mode === 'new-default') {
+        title = '일반 채팅';
+        subtitle = '자유롭게 대화를 시작하세요';
+        chatCountText = '새 채팅';
+    } else {
+        title = workflow.name;
+        subtitle = '새로운 대화를 시작하세요';
+        chatCountText = '새 채팅';
+    }
+
+    const showBackButton = (!isExistingMode || !hideBackButton);
+
+    return (
+        <div className={styles.header}>
+            <div className={styles.headerInfo}>
+                {showBackButton && (
+                    <button className={styles.backButton} onClick={onBack}>
+                        <FiArrowLeft />
+                    </button>
+                )}
+                <div>
+                    <h2>{title}</h2>
+                    <p>{subtitle}</p>
+                </div>
+            </div>
+            <div className={styles.chatCount}>
+                <FiMessageSquare />
+                <span>{chatCountText}</span>
+            </div>
+        </div>
+    );
+};
+
+export default ChatHeader;

--- a/src/app/chat/components/ChatInterface.tsx
+++ b/src/app/chat/components/ChatInterface.tsx
@@ -17,43 +17,14 @@ import { getWorkflowIOLogs, executeWorkflowById } from '@/app/api/workflowAPI';
 import { MessageRenderer } from '@/app/utils/chatParser';
 import toast from 'react-hot-toast';
 import CollectionModal from '@/app/chat/components/CollectionModal';
+import { IOLog, ChatInterfaceProps } from './types';
+import ChatHeader from './ChatHeader';
+import { ChatArea } from './ChatArea';
 
-interface Workflow {
-    id: string;
-    name: string;
-    description?: string;
-    createdAt?: string;
-    lastModified?: string;
-    author: string;
-    nodeCount: number;
-    status: 'active' | 'draft' | 'archived';
-    filename?: string;
-    error?: string;
-}
 
-interface IOLog {
-    log_id: number | string;
-    workflow_name: string;
-    workflow_id: string;
-    input_data: string;
-    output_data: string;
-    updated_at: string;
-}
-
-interface ChatInterfaceProps {
-    workflow: Workflow;
-    onBack: () => void;
-    hideBackButton?: boolean;
-    existingChatData?: {
-        interactionId: string;
-        workflowId: string;
-        workflowName: string;
-    } | null;
-}
-
-const ChatInterface: React.FC<ChatInterfaceProps> = ({ workflow, onBack, hideBackButton = false, existingChatData }) => {
+const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, hideBackButton = false, existingChatData }) => {
     const [ioLogs, setIOLogs] = useState<IOLog[]>([]);
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(false);
     const [executing, setExecuting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [inputMessage, setInputMessage] = useState<string>('');
@@ -66,10 +37,29 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ workflow, onBack, hideBac
     const attachmentButtonRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        if (workflow?.id && existingChatData?.interactionId) {
+        const loadChatLogs = async () => {
+            try {
+                setLoading(true);
+                setError(null);
+
+                const interactionId = existingChatData?.interactionId || 'default';
+                const workflowName = existingChatData?.workflowName || workflow.name;
+                const workflowId = existingChatData?.workflowId || workflow.id;
+
+                const logs = await getWorkflowIOLogs(workflowName, workflowId, interactionId);
+                setIOLogs((logs as any).in_out_logs || []);
+                setPendingLogId(null);
+            } catch (err) {
+                setError('채팅 기록을 불러오는데 실패했습니다.');
+                setIOLogs([]);
+            } finally {
+                setLoading(false);
+            }
+        };
+        if (mode === 'existing' && workflow?.id && existingChatData?.interactionId) {
             loadChatLogs();
         }
-    }, [workflow?.id, existingChatData?.interactionId, existingChatData?.workflowId]);
+    }, [mode, existingChatData?.interactionId, workflow.id, workflow.name, existingChatData?.workflowName, existingChatData?.workflowId]);
 
     useEffect(() => {
         scrollToBottom();
@@ -130,26 +120,6 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ workflow, onBack, hideBac
     const scrollToBottom = () => {
         if (messagesRef.current) {
             messagesRef.current.scrollTop = messagesRef.current.scrollHeight;
-        }
-    };
-
-    const loadChatLogs = async () => {
-        try {
-            setLoading(true);
-            setError(null);
-
-            const interactionId = existingChatData?.interactionId || 'default';
-            const workflowName = existingChatData?.workflowName || workflow.name;
-            const workflowId = existingChatData?.workflowId || workflow.id;
-
-            const logs = await getWorkflowIOLogs(workflowName, workflowId, interactionId);
-            setIOLogs((logs as any).in_out_logs || []);
-            setPendingLogId(null);
-        } catch (err) {
-            setError('채팅 기록을 불러오는데 실패했습니다.');
-            setIOLogs([]);
-        } finally {
-            setLoading(false);
         }
     };
 
@@ -308,166 +278,128 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ workflow, onBack, hideBac
 
     return (
         <div className={styles.container}>
-            {/* Header */}
-            <div className={styles.header}>
-                <div className={styles.headerInfo}>
-                    {!hideBackButton && (
-                        <button className={styles.backButton} onClick={onBack}>
-                            <FiArrowLeft />
-                        </button>
-                    )}
-                    <div>
-                        <h2>{workflow.name === 'default_mode' ? '일반 채팅' : workflow.name}</h2>
-                        <p>{hideBackButton ? '현재 채팅을 계속하세요' : '기존 대화를 계속하세요'}</p>
-                    </div>
-                </div>
-                <div className={styles.chatCount}>
-                    <FiMessageSquare />
-                    <span>{ioLogs.length}개의 대화</span>
-                </div>
-            </div>
+            <ChatHeader 
+                mode={mode} 
+                workflow={workflow} 
+                ioLogs={ioLogs} 
+                onBack={onBack}
+                hideBackButton={hideBackButton}
+            ></ChatHeader>
 
             {/* Chat Area */}
             <div className={styles.chatContainer}>
-                {loading ? (
-                    <div className={styles.loadingState}>
-                        <div className={styles.loadingSpinner}></div>
-                        <p>채팅 기록을 불러오는 중...</p>
-                    </div>
-                ) : (
-                    <>
-                        <div ref={messagesRef} className={styles.messagesArea}>
-                            {ioLogs.length === 0 ? (
-                                <div className={styles.emptyState}>
-                                    <FiClock className={styles.emptyIcon} />
-                                    <h3>대화 기록이 없습니다</h3>
-                                    <p>&quot;{workflow.name}&quot; 워크플로우의 이전 대화를 불러올 수 없습니다.</p>
-                                    <p>새로운 대화를 시작해보세요.</p>
-                                </div>
-                            ) : (
-                                ioLogs.map((log) => (
-                                    <div key={log.log_id} className={styles.messageExchange}>
-                                        {/* User Message */}
-                                        <div className={styles.userMessage}>
-                                            <div className={styles.messageContent}>
-                                                {renderMessageContent(log.input_data, true)}
-                                            </div>
-                                            <div className={styles.messageTime}>
-                                                {formatDate(log.updated_at)}
-                                            </div>
-                                        </div>
+                {/* Chat Area */}
+                <ChatArea 
+                    mode={mode}
+                    loading={loading}
+                    ioLogs={ioLogs}
+                    workflow={workflow}
+                    executing={executing} 
+                    setInputMessage={setInputMessage} 
+                    messagesRef={messagesRef} 
+                    pendingLogId={pendingLogId} 
+                    renderMessageContent={renderMessageContent} 
+                    formatDate={formatDate}
+                ></ChatArea>
 
-                                        {/* Bot Message */}
-                                        <div className={styles.botMessage}>
-                                            <div className={styles.messageContent}>
-                                                {String(log.log_id) === pendingLogId && executing && !log.output_data ? (
-                                                    <div className={styles.typingIndicator}>
-                                                        <span></span>
-                                                        <span></span>
-                                                        <span></span>
-                                                    </div>
-                                                ) : (
-                                                    renderMessageContent(log.output_data)
-                                                )}
-                                            </div>
-                                        </div>
+                <>
+                    {/* Input Area */}
+                    <div className={styles.inputArea} style={{ pointerEvents: loading ? 'none' : 'auto' }}>
+                        <div className={styles.inputContainer}>
+                            <input
+                                type="text"
+                                placeholder="메시지를 입력하세요..."
+                                value={inputMessage}
+                                onChange={(e) => setInputMessage(e.target.value)}
+                                onKeyPress={handleKeyPress}
+                                disabled={executing}
+                                className={styles.messageInput}
+                            />
+                            <div className={styles.buttonGroup}>
+                                {selectedCollection && (
+                                    <div className={styles.selectedCollection}>
+                                        <FiBookmark className={styles.collectionIcon} />
+                                        <span className={styles.collectionName}>{selectedCollection}</span>
+                                        <button
+                                            className={styles.removeCollectionButton}
+                                            onClick={handleRemoveCollection}
+                                            title="컬렉션 해제"
+                                        >
+                                            <FiX />
+                                        </button>
                                     </div>
-                                ))
-                            )}
-                        </div>
-
-
-                        {/* Input Area */}
-                        <div className={styles.inputArea}>
-                            <div className={styles.inputContainer}>
-                                <input
-                                    type="text"
-                                    placeholder="메시지를 입력하세요..."
-                                    value={inputMessage}
-                                    onChange={(e) => setInputMessage(e.target.value)}
-                                    onKeyPress={handleKeyPress}
-                                    disabled={executing}
-                                    className={styles.messageInput}
-                                />
-                                <div className={styles.buttonGroup}>
-                                    {selectedCollection && (
-                                        <div className={styles.selectedCollection}>
-                                            <FiBookmark className={styles.collectionIcon} />
-                                            <span className={styles.collectionName}>{selectedCollection}</span>
+                                )}
+                                <div className={styles.attachmentWrapper} ref={attachmentButtonRef}>
+                                    <button
+                                        onClick={handleAttachmentClick}
+                                        className={`${styles.attachmentButton} ${showAttachmentMenu ? styles.active : ''}`}
+                                        disabled={executing}
+                                    >
+                                        <FiPlus />
+                                    </button>
+                                    {showAttachmentMenu && (
+                                        <div className={styles.attachmentMenu}>
                                             <button
-                                                className={styles.removeCollectionButton}
-                                                onClick={handleRemoveCollection}
-                                                title="컬렉션 해제"
+                                                className={styles.attachmentOption}
+                                                onClick={() => handleAttachmentOption('collection')}
                                             >
-                                                <FiX />
+                                                <FiBookmark />
+                                                <span>컬렉션</span>
+                                            </button>
+                                            <button
+                                                className={`${styles.attachmentOption} ${styles.disabled}`}
+                                                disabled
+                                            >
+                                                <FiFolder />
+                                                <span>파일</span>
+                                            </button>
+                                            <button
+                                                className={`${styles.attachmentOption} ${styles.disabled}`}
+                                                disabled
+                                            >
+                                                <FiImage />
+                                                <span>사진</span>
+                                            </button>
+                                            <button
+                                                className={`${styles.attachmentOption} ${styles.disabled}`}
+                                                disabled
+                                            >
+                                                <FiMic />
+                                                <span>음성</span>
                                             </button>
                                         </div>
                                     )}
-                                    <div className={styles.attachmentWrapper} ref={attachmentButtonRef}>
-                                        <button
-                                            onClick={handleAttachmentClick}
-                                            className={`${styles.attachmentButton} ${showAttachmentMenu ? styles.active : ''}`}
-                                            disabled={executing}
-                                        >
-                                            <FiPlus />
-                                        </button>
-                                        {showAttachmentMenu && (
-                                            <div className={styles.attachmentMenu}>
-                                                <button
-                                                    className={styles.attachmentOption}
-                                                    onClick={() => handleAttachmentOption('collection')}
-                                                >
-                                                    <FiBookmark />
-                                                    <span>컬렉션</span>
-                                                </button>
-                                                <button
-                                                    className={`${styles.attachmentOption} ${styles.disabled}`}
-                                                    disabled
-                                                >
-                                                    <FiFolder />
-                                                    <span>파일</span>
-                                                </button>
-                                                <button
-                                                    className={`${styles.attachmentOption} ${styles.disabled}`}
-                                                    disabled
-                                                >
-                                                    <FiImage />
-                                                    <span>사진</span>
-                                                </button>
-                                                <button
-                                                    className={`${styles.attachmentOption} ${styles.disabled}`}
-                                                    disabled
-                                                >
-                                                    <FiMic />
-                                                    <span>음성</span>
-                                                </button>
-                                            </div>
-                                        )}
-                                    </div>
-                                    <button
-                                        onClick={executeWorkflow}
-                                        disabled={executing || !inputMessage.trim()}
-                                        className={`${styles.sendButton} ${executing || !inputMessage.trim() ? styles.disabled : ''}`}
-                                    >
-                                        {executing ? (
-                                            <div className={styles.miniSpinner}></div>
-                                        ) : (
-                                            <FiSend />
-                                        )}
-                                    </button>
                                 </div>
+                                <button
+                                    onClick={executeWorkflow}
+                                    disabled={executing || !inputMessage.trim()}
+                                    className={`${styles.sendButton} ${executing || !inputMessage.trim() ? styles.disabled : ''}`}
+                                >
+                                    {executing ? (
+                                        <div className={styles.miniSpinner}></div>
+                                    ) : (
+                                        <FiSend />
+                                    )}
+                                </button>
                             </div>
-                            {executing && (
+                        </div>
+                        {executing && (
+                            mode === "new-default" ? (
+                                <p className={styles.executingNote}>
+                                    일반 채팅을 실행 중입니다...
+                                </p>
+                            ) : (
                                 <p className={styles.executingNote}>
                                     워크플로우를 실행 중입니다...
                                 </p>
-                            )}
-                            {error && (
-                                <p className={styles.errorNote}>{error}</p>
-                            )}
-                        </div>
-                    </>
-                )}
+                            )
+                            
+                        )}
+                        {error && (
+                            <p className={styles.errorNote}>{error}</p>
+                        )}
+                    </div>
+                </>
             </div>
 
             {/* Collection Modal */}

--- a/src/app/chat/components/ChatPageContent.tsx
+++ b/src/app/chat/components/ChatPageContent.tsx
@@ -4,7 +4,6 @@ import Sidebar from '@/app/_common/components/Sidebar';
 import ChatHistory from '@/app/chat/components/ChatHistory';
 import CurrentChatInterface from '@/app/chat/components/CurrentChatInterface';
 import ChatContent from '@/app/chat/components/ChatContent';
-import DefaultChatInterface from '@/app/chat/components/DefaultChatInterface';
 import { getChatSidebarItems, getSettingSidebarItems, createItemClickHandler } from '@/app/_common/components/sidebarConfig';
 import styles from '@/app/main/assets/MainPage.module.scss';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';

--- a/src/app/chat/components/CurrentChatInterface.tsx
+++ b/src/app/chat/components/CurrentChatInterface.tsx
@@ -83,6 +83,7 @@ const CurrentChatInterface: React.FC<CurrentChatInterfaceProps> = ({ onBack }) =
         <div className={chatContentStyles.chatContainer}>
             <div className={chatContentStyles.workflowSection}>
                 <ChatInterface
+                    mode="existing"
                     workflow={workflow}
                     existingChatData={existingChatData}
                     hideBackButton={true}

--- a/src/app/chat/components/EmptyState.tsx
+++ b/src/app/chat/components/EmptyState.tsx
@@ -1,0 +1,28 @@
+
+import { FiClock } from 'react-icons/fi';
+import styles from '@/app/chat/assets/ChatInterface.module.scss';
+import { SuggestionChips } from './SuggestionChips';
+
+
+interface EmptyStateProps {
+    icon?: React.ReactNode;
+    title: string;
+    children?: React.ReactNode;
+    showSuggestions?: boolean;
+    onChipClick?: (text: string) => void;
+    disabled?: boolean;
+}
+export const EmptyState: React.FC<EmptyStateProps> = ({ icon, title, children, showSuggestions, onChipClick, disabled }) => {
+    return (
+        <div className={styles.emptyState}>
+            {icon || <FiClock className={styles.emptyIcon} />}
+            <h3>{title}</h3>
+            {children}
+            {showSuggestions && (
+                <div className={styles.welcomeActions}>
+                    <SuggestionChips onChipClick={onChipClick} disabled={disabled} />
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/app/chat/components/MessageList.tsx
+++ b/src/app/chat/components/MessageList.tsx
@@ -1,0 +1,36 @@
+import styles from '@/app/chat/assets/ChatInterface.module.scss';
+import { IOLog } from './types';
+
+interface MessageListProps {
+    ioLogs: IOLog[];
+    pendingLogId: string | null;
+    executing: boolean;
+    renderMessageContent: (content: string, isUserMessage?: boolean) => React.ReactNode;
+    formatDate: (dateString: string) => string;
+}
+export const MessageList: React.FC<MessageListProps> = ({ ioLogs, pendingLogId, executing, renderMessageContent, formatDate }) => {
+    return ioLogs.map((log) => (
+        <div key={log.log_id} className={styles.messageExchange}>
+            <div className={styles.userMessage}>
+                <div className={styles.messageContent}>
+                    {renderMessageContent(log.input_data, true)}
+                </div>
+                <div className={styles.messageTime}>
+                    {formatDate(log.updated_at)}
+                </div>
+            </div>
+
+            <div className={styles.botMessage}>
+                <div className={styles.messageContent}>
+                    {String(log.log_id) === pendingLogId && executing && !log.output_data ? (
+                        <div className={styles.typingIndicator}>
+                            <span /><span /><span />
+                        </div>
+                    ) : (
+                        renderMessageContent(log.output_data)
+                    )}
+                </div>
+            </div>
+        </div>
+    ));
+};

--- a/src/app/chat/components/SuggestionChips.tsx
+++ b/src/app/chat/components/SuggestionChips.tsx
@@ -1,0 +1,25 @@
+import styles from '@/app/chat/assets/ChatInterface.module.scss';
+
+interface SuggestionChipsProps {
+    onChipClick?: (text: string) => void;
+    disabled?: boolean;
+}
+
+export const SuggestionChips: React.FC<SuggestionChipsProps> = ({ onChipClick, disabled }) => {
+    const suggestions = ['안녕하세요!', '도움이 필요해요', '어떤 기능이 있나요?'];
+
+    return (
+        <div className={styles.suggestionChips}>
+            {suggestions.map((text) => (
+                <button
+                    key={text}
+                    className={styles.suggestionChip}
+                    onClick={() => onChipClick?.(text)}
+                    disabled={disabled}
+                >
+                    {text}
+                </button>
+            ))}
+        </div>
+    );
+};

--- a/src/app/chat/components/types.tsx
+++ b/src/app/chat/components/types.tsx
@@ -1,0 +1,42 @@
+export interface Workflow {
+    id: string;
+    name: string;
+    description?: string;
+    createdAt?: string;
+    lastModified?: string;
+    author: string;
+    nodeCount: number;
+    status: 'active' | 'draft' | 'archived';
+    filename?: string;
+    error?: string;
+}
+
+export interface IOLog {
+    log_id: number | string;
+    workflow_name: string;
+    workflow_id: string;
+    input_data: string;
+    output_data: string;
+    updated_at: string;
+}
+
+export interface ChatInterfaceProps {
+    mode: 'existing' | 'new-workflow' | 'new-default';
+    workflow: Workflow;
+    onChatStarted?: (newInteractionId: string) => void;
+    onBack: () => void;
+    hideBackButton?: boolean;
+    existingChatData?: {
+        interactionId: string;
+        workflowId: string;
+        workflowName: string;
+    } | null;
+}
+
+export interface ChatHeaderProps {
+    mode: 'existing' | 'new-workflow' | 'new-default';
+    workflow: Workflow;
+    ioLogs: IOLog[];
+    onBack: () => void;
+    hideBackButton?: boolean;
+}


### PR DESCRIPTION
### 설명
- 기존에 분리되어 있던 `NewChatInterface`, `DefaultChatInterface`, `ChatInterface` 등의 컴포넌트를 하나로 통합하여 모드별(chat mode: 기존, 신규 워크플로우, 일반 채팅) 렌더링을 간소화했습니다.
- 채팅 모드별 UI 로직을 명확하게 분리하고, 코드 중복을 제거하여 유지보수성을 향상시켰습니다.
- 채팅 헤더와 채팅 영역을 분리하여 역할을 분명히 하였고, 커스텀 컴포넌트(`ChatArea`, `ChatHeader`, `MessageList`, `EmptyState`, `SuggestionChips`)를 도입해 재사용성을 높였습니다.
- 기존 워크플로우 이력 불러오기 로직을 `mode` 상태를 기반으로 실행하도록 변경하여 로딩 및 에러 관리를 효율적으로 처리합니다.

### 주요 변경 사항
- `ChatInterface` 컴포넌트를 모든 채팅 모드를 지원하도록 수정하고, 모드별 렌더링 분기를 추가함.
- `ChatContent` 컴포넌트 내 기존, 신규 워크플로우, 기본 채팅 모드 구분 로직을 `mode` 상태 관리로 변경 및 간소화.
- 채팅 헤더 UI를 별도 컴포넌트 `ChatHeader`로 분리하여 모드별 타이틀, 부제목, 대화 수 표시 로직 구현.
- 채팅 메시지 영역을 `ChatArea` 컴포넌트로 분리하고, 모드별 메시지 및 빈 상태 처리 로직 통합.
- 이전에 각각 분리되어 있던 메시지 리스트, 빈 상태, 제안 칩 UI를 각각 `MessageList`, `EmptyState`, `SuggestionChips` 컴포넌트로 분리.
- 기존 채팅 이력 불러오기 (`getWorkflowIOLogs`)와 로딩 상태 관리를 모드에 따라 조건부로 실행하도록 개선.
- 입력창 및 첨부파일, 컬렉션 선택 UI 동작을 유지하면서 모드별 실행 상태에 따라 UI 렌더링을 유연하게 변경.
- 관련 타입 정의를 `types.tsx`로 분리해 명확히 관리.
- 불필요한 `NewChatInterface`, `DefaultChatInterface` 컴포넌트 삭제 및 사용 중지
- 스타일링과 아이콘 활용은 유지하며 컴포넌트 재사용성을 높임.