### PR TITLE
[기능] 배포 모드 및 배포 정보 모달 UI 추가

### DIFF
--- a/src/app/chat/assets/ChatInterface.module.scss
+++ b/src/app/chat/assets/ChatInterface.module.scss
@@ -833,6 +833,30 @@ $white: #ffffff;
     }
 }
 
+.closeButton {
+    background: none;
+    border: none;
+    padding: 0.5rem;
+    margin: -0.5rem;
+    cursor: pointer;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $gray-500;
+    transition: all 0.2s ease;
+
+    &:hover {
+        background-color: $gray-100;
+        color: $gray-800;
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+    }
+}
+
 .deploymentModalContent {
     padding: 1.5rem;
     overflow-y: auto;
@@ -894,6 +918,59 @@ $white: #ffffff;
     white-space: pre-wrap;
     word-break: break-all;
     font-size: 0.875rem;
+}
+
+.tabContainer {
+    display: flex;
+    border-bottom: 1px solid $gray-200;
+    padding: 0 1.5rem;
+    margin-top: 0.5rem;
+}
+
+.tabButton {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: $gray-500;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s ease-in-out;
+    margin-bottom: -1px;
+
+    &:hover {
+        color: $gray-800;
+    }
+
+    &.active {
+        color: $primary-blue;
+        border-bottom-color: $primary-blue;
+    }
+}
+
+.deploymentModalContent {
+    padding: 0;
+    overflow-y: auto;
+    max-height: calc(80vh - 120px);
+}
+
+.tabPanel {
+    padding: 1.5rem;
+
+    p {
+        font-size: 0.875rem;
+        color: $gray-600;
+        margin: 0 0 1rem 0;
+    }
+
+    h5 {
+      margin-top: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
 }
 
 // Responsive Design

--- a/src/app/chat/assets/ChatInterface.module.scss
+++ b/src/app/chat/assets/ChatInterface.module.scss
@@ -769,6 +769,133 @@ $white: #ffffff;
     }
 }
 
+.headerActions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.deployButton {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: $primary-green;
+    color: $white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+
+    &:hover {
+        background: #047857;
+        transform: translateY(-1px);
+    }
+}
+
+// Deployment Modal Styles
+.deploymentModalBackdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+.deploymentModalContainer {
+    background: $white;
+    border-radius: 0.75rem;
+    width: 90%;
+    max-width: 700px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.deploymentModalHeader {
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid $gray-200;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    h3 {
+        margin: 0;
+        font-size: 1.125rem;
+        font-weight: 600;
+    }
+}
+
+.deploymentModalContent {
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+
+.deploymentSection {
+    margin-bottom: 2rem;
+
+    h4 {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        margin: 0 0 0.75rem 0;
+    }
+    
+    p {
+        font-size: 0.875rem;
+        color: $gray-600;
+        margin: 0 0 1rem 0;
+    }
+}
+
+.webPageUrl {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: $gray-100;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+
+    a {
+        flex: 1;
+        color: $primary-blue;
+        text-decoration: none;
+        word-break: break-all;
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    button {
+        background: $primary-blue;
+        color: $white;
+        border: none;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.375rem;
+        cursor: pointer;
+    }
+}
+
+.codeSnippet {
+    background: $gray-800;
+    color: $gray-100;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    font-family: monospace;
+    white-space: pre-wrap;
+    word-break: break-all;
+    font-size: 0.875rem;
+}
+
 // Responsive Design
 @media (max-width: 768px) {
     .header {

--- a/src/app/chat/components/ChatArea.tsx
+++ b/src/app/chat/components/ChatArea.tsx
@@ -5,7 +5,7 @@ import { EmptyState } from './EmptyState';
 import { IOLog, Workflow } from './types';
 
 interface ChatAreaProps {
-    mode: "existing" | "new-workflow" | "new-default";
+    mode: "existing" | "new-workflow" | "new-default" | "deploy";
     loading: boolean;
     ioLogs: IOLog[];
     workflow: Workflow;

--- a/src/app/chat/components/ChatContent.tsx
+++ b/src/app/chat/components/ChatContent.tsx
@@ -24,7 +24,6 @@ const ChatContentInner: React.FC<ChatContentProps> = ({ onChatStarted }) => {
         const workflowName = searchParams.get('workflow_name');
 
         if (mode === 'existing' && interactionId && workflowId && workflowName) {
-            // 기존 채팅 정보를 설정하고 바로 채팅 화면으로 이동
             const existingWorkflow = {
                 id: workflowId,
                 name: workflowName,

--- a/src/app/chat/components/ChatHeader.tsx
+++ b/src/app/chat/components/ChatHeader.tsx
@@ -1,8 +1,8 @@
-import { FiArrowLeft, FiMessageSquare } from 'react-icons/fi';
+import { FiArrowLeft, FiMessageSquare, FiUpload } from 'react-icons/fi';
 import styles from '@/app/chat/assets/ChatInterface.module.scss';
 import { ChatHeaderProps } from './types';
 
-const ChatHeader: React.FC<ChatHeaderProps> = ({ mode, workflow, ioLogs, onBack, hideBackButton }) => {
+const ChatHeader: React.FC<ChatHeaderProps> = ({ mode, workflow, ioLogs, onBack, hideBackButton, onDeploy }) => {
     let title = '';
     let subtitle = '';
     let chatCountText = '';
@@ -39,9 +39,15 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({ mode, workflow, ioLogs, onBack,
                 </div>
             </div>
             <div className={styles.chatCount}>
+                <button className={styles.deployButton} onClick={onDeploy}>
+                    <FiUpload />
+                    <span>배포</span>
+                </button>
                 <FiMessageSquare />
                 <span>{chatCountText}</span>
+                
             </div>
+            
         </div>
     );
 };

--- a/src/app/chat/components/ChatHeader.tsx
+++ b/src/app/chat/components/ChatHeader.tsx
@@ -17,6 +17,10 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({ mode, workflow, ioLogs, onBack,
         title = '일반 채팅';
         subtitle = '자유롭게 대화를 시작하세요';
         chatCountText = '새 채팅';
+    } else if (mode === 'new-workflow') {
+        title = workflow.name;
+        subtitle = '새로운 대화를 시작하세요';
+        chatCountText = '새 채팅';
     } else {
         title = workflow.name;
         subtitle = '새로운 대화를 시작하세요';
@@ -39,10 +43,14 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({ mode, workflow, ioLogs, onBack,
                 </div>
             </div>
             <div className={styles.chatCount}>
-                <button className={styles.deployButton} onClick={onDeploy}>
-                    <FiUpload />
-                    <span>배포</span>
-                </button>
+                { mode === 'deploy' ? (
+                    <span></span>
+                ) : (
+                    <button className={styles.deployButton} onClick={onDeploy}>
+                        <FiUpload />
+                        <span>배포</span>
+                    </button>
+                )}
                 <FiMessageSquare />
                 <span>{chatCountText}</span>
                 

--- a/src/app/chat/components/ChatInterface.tsx
+++ b/src/app/chat/components/ChatInterface.tsx
@@ -20,6 +20,7 @@ import CollectionModal from '@/app/chat/components/CollectionModal';
 import { IOLog, ChatInterfaceProps } from './types';
 import ChatHeader from './ChatHeader';
 import { ChatArea } from './ChatArea';
+import { DeploymentModal } from './DeploymentModal';
 
 
 const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, hideBackButton = false, existingChatData }) => {
@@ -32,6 +33,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, h
     const [showAttachmentMenu, setShowAttachmentMenu] = useState(false);
     const [showCollectionModal, setShowCollectionModal] = useState(false);
     const [selectedCollection, setSelectedCollection] = useState<string | null>(null);
+    const [showDeploymentModal, setShowDeploymentModal] = useState(false);
+
 
     const messagesRef = useRef<HTMLDivElement>(null);
     const attachmentButtonRef = useRef<HTMLDivElement>(null);
@@ -284,6 +287,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, h
                 ioLogs={ioLogs} 
                 onBack={onBack}
                 hideBackButton={hideBackButton}
+                onDeploy={() => setShowDeploymentModal(true)}
             ></ChatHeader>
 
             {/* Chat Area */}
@@ -401,6 +405,11 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, h
                     </div>
                 </>
             </div>
+            <DeploymentModal
+                isOpen={showDeploymentModal}
+                onClose={() => setShowDeploymentModal(false)}
+                workflow={workflow}
+            />
 
             {/* Collection Modal */}
             <CollectionModal

--- a/src/app/chat/components/DeploymentModal.tsx
+++ b/src/app/chat/components/DeploymentModal.tsx
@@ -1,7 +1,7 @@
 import styles from '@/app/chat/assets/ChatInterface.module.scss';
 import { FiCode, FiExternalLink, FiX } from 'react-icons/fi';
 import { Workflow } from './types';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface DeploymentModalProps {
     isOpen: boolean;
@@ -9,6 +9,21 @@ interface DeploymentModalProps {
     workflow: Workflow;
 }
 export const DeploymentModal: React.FC<DeploymentModalProps> = ({ isOpen, onClose, workflow }) => {
+    const [baseUrl, setBaseUrl] = useState('');
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            setBaseUrl(window.location.origin);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (isOpen) {
+            setTimeout(() => closeButtonRef.current?.focus(), 100);
+        }
+    }, [isOpen]);
+
     if (!isOpen) return null;
 
     const handleBackdropKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -18,8 +33,9 @@ export const DeploymentModal: React.FC<DeploymentModalProps> = ({ isOpen, onClos
     };
 
     const chatId = workflow.id;
-    const apiEndpoint = `https://polar-comfy.x2bee.com/api/v1/prediction/${chatId}`;
-    const webPageUrl = `https://polar-comfy.x2bee.com/chatbot/${chatId}`;
+    const workflowName = encodeURIComponent(workflow.name);
+    const apiEndpoint = `${baseUrl}/api/v1/prediction/${chatId}`;
+    const webPageUrl = `${baseUrl}/chatbot/${chatId}?workflowName=${workflowName}`;
 
     const pythonApiCode = `import requests
 
@@ -52,12 +68,6 @@ query({"question": "Hey, how are you?"}).then((response) => {
 });
 `;
 
-    const closeButtonRef = useRef<HTMLButtonElement>(null);
-        useEffect(() => {
-            if (isOpen) {
-                closeButtonRef.current?.focus();
-            }
-        }, [isOpen]);
 
     return (
         <div
@@ -65,12 +75,11 @@ query({"question": "Hey, how are you?"}).then((response) => {
             onClick={onClose}
             onKeyDown={handleBackdropKeyDown}
             role="button"
-            tabIndex={-1} 
+            tabIndex={-1}
             aria-label="Close deployment modal"
         >
             <div
                 className={styles.deploymentModalContainer}
-                onClick={(e) => e.stopPropagation()}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="deployment-modal-title"

--- a/src/app/chat/components/DeploymentModal.tsx
+++ b/src/app/chat/components/DeploymentModal.tsx
@@ -1,0 +1,110 @@
+import styles from '@/app/chat/assets/ChatInterface.module.scss';
+import { FiCode, FiExternalLink, FiX } from 'react-icons/fi';
+import { Workflow } from './types';
+import { useEffect, useRef } from 'react';
+
+interface DeploymentModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    workflow: Workflow;
+}
+export const DeploymentModal: React.FC<DeploymentModalProps> = ({ isOpen, onClose, workflow }) => {
+    if (!isOpen) return null;
+
+    const handleBackdropKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Escape') {
+            onClose();
+        }
+    };
+
+    const chatId = workflow.id;
+    const apiEndpoint = `https://polar-comfy.x2bee.com/api/v1/prediction/${chatId}`;
+    const webPageUrl = `https://polar-comfy.x2bee.com/chatbot/${chatId}`;
+
+    const pythonApiCode = `import requests
+
+API_URL = "${apiEndpoint}"
+
+def query(payload):
+    response = requests.post(API_URL, json=payload)
+    return response.json()
+
+output = query({
+    "question": "Hey, how are you?",
+})
+`;
+
+    const jsApiCode = `async function query(data) {
+    const response = await fetch(
+        "${apiEndpoint}",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data)
+        }
+    );
+    const result = await response.json();
+    return result;
+}
+
+query({"question": "Hey, how are you?"}).then((response) => {
+    console.log(response);
+});
+`;
+
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
+        useEffect(() => {
+            if (isOpen) {
+                closeButtonRef.current?.focus();
+            }
+        }, [isOpen]);
+
+    return (
+        <div
+            className={styles.deploymentModalBackdrop}
+            onClick={onClose}
+            onKeyDown={handleBackdropKeyDown}
+            role="button"
+            tabIndex={-1} 
+            aria-label="Close deployment modal"
+        >
+            <div
+                className={styles.deploymentModalContainer}
+                onClick={(e) => e.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="deployment-modal-title"
+            >
+                <div className={styles.deploymentModalHeader}>
+                    <h3 id="deployment-modal-title">배포 정보: {workflow.name}</h3>
+                    <button
+                        ref={closeButtonRef}
+                        onClick={onClose}
+                        className={styles.closeButton}
+                        aria-label="Close"
+                    >
+                        <FiX />
+                    </button>
+                </div>
+                <div className={styles.deploymentModalContent}>
+                    <div className={styles.deploymentSection}>
+                        <h4><FiExternalLink /> 독립 웹페이지</h4>
+                        <p>아래 링크를 통해 독립된 웹페이지에서 채팅을 사용할 수 있습니다.</p>
+                        <div className={styles.webPageUrl}>
+                            <a href={webPageUrl} target="_blank" rel="noopener noreferrer">{webPageUrl}</a>
+                            <button onClick={() => navigator.clipboard.writeText(webPageUrl)}>Copy</button>
+                        </div>
+                    </div>
+                    <div className={styles.deploymentSection}>
+                        <h4><FiCode /> API 연동</h4>
+                        <p>아래 코드를 사용하여 API를 통해 워크플로우를 호출할 수 있습니다.</p>
+                        <h5>Python</h5>
+                        <pre className={styles.codeSnippet}>{pythonApiCode}</pre>
+                        <h5>JavaScript</h5>
+                        <pre className={styles.codeSnippet}>{jsApiCode}</pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/app/chat/components/types.tsx
+++ b/src/app/chat/components/types.tsx
@@ -21,7 +21,7 @@ export interface IOLog {
 }
 
 export interface ChatInterfaceProps {
-    mode: 'existing' | 'new-workflow' | 'new-default';
+    mode: 'existing' | 'new-workflow' | 'new-default' | 'deploy';
     workflow: Workflow;
     onChatStarted?: (newInteractionId: string) => void;
     onBack: () => void;
@@ -34,7 +34,7 @@ export interface ChatInterfaceProps {
 }
 
 export interface ChatHeaderProps {
-    mode: 'existing' | 'new-workflow' | 'new-default';
+    mode: 'existing' | 'new-workflow' | 'new-default' | 'deploy';
     workflow: Workflow;
     ioLogs: IOLog[];
     onBack: () => void;

--- a/src/app/chat/components/types.tsx
+++ b/src/app/chat/components/types.tsx
@@ -39,4 +39,5 @@ export interface ChatHeaderProps {
     ioLogs: IOLog[];
     onBack: () => void;
     hideBackButton?: boolean;
+    onDeploy?: () => void;
 }

--- a/src/app/chatbot/[chatId]/StandaloneChat.module.scss
+++ b/src/app/chatbot/[chatId]/StandaloneChat.module.scss
@@ -1,0 +1,58 @@
+.pageContainer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    width: 100vw;
+    background-color: #f0f2f5; 
+
+    & > div {
+        width: 100%;
+        height: 100%;
+        max-width: 1200px;
+        border-radius: 0;
+        box-shadow: none;
+    }
+}
+
+.centeredMessage {
+    text-align: center;
+    color: #4b5563;
+
+    h2 {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .homeButton {
+        margin-top: 1.5rem;
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 0.5rem;
+        background-color: #10b981;
+        color: white;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: background-color 0.2s;
+
+        &:hover {
+            background-color: #059669;
+        }
+    }
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid rgba(0, 0, 0, 0.1);
+    border-left-color: #10b981;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 1rem;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/app/chatbot/[chatId]/page.tsx
+++ b/src/app/chatbot/[chatId]/page.tsx
@@ -79,11 +79,12 @@ const StandaloneChatPage = () => {
     return (
         <div className={styles.pageContainer}>
             <ChatInterface
-                mode="new-workflow"
+                mode="deploy"
                 workflow={workflow}
                 onBack={() => {}}
+                onChatStarted={() => {}}
                 hideBackButton={true}
-                existingChatData={null}
+                existingChatData={undefined}
             />
         </div>
     );

--- a/src/app/chatbot/[chatId]/page.tsx
+++ b/src/app/chatbot/[chatId]/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { loadWorkflow } from '@/app/api/workflowAPI';
+import ChatInterface from '@/app/chat/components/ChatInterface';
+import { Workflow } from '@/app/chat/components/types';
+import styles from './StandaloneChat.module.scss';
+
+const StandaloneChatPage = () => {
+    const params = useParams();
+    const searchParams = useSearchParams();
+    const router = useRouter();
+    const chatId = params.chatId as string;
+    const workflowNameFromUrl = searchParams.get('workflowName') as string;
+
+
+    const [workflow, setWorkflow] = useState<Workflow | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!chatId) {
+            setError('잘못된 접근입니다. 워크플로우 ID가 필요합니다.');
+            setLoading(false);
+            return;
+        }
+
+        const fetchWorkflow = async () => {
+            try {
+                setLoading(true);
+                const fetchedWorkflow: Workflow | null = {
+                    id: chatId,
+                    name: workflowNameFromUrl,
+                    filename: workflowNameFromUrl,
+                    author: 'Unknown',
+                    nodeCount: 0,
+                    status: 'active' as const,
+                };
+                setWorkflow(fetchedWorkflow);
+                setError(null);
+            } catch (err) {
+                console.error(err);
+                setError('워크플로우를 불러오는 데 실패했습니다. ID를 확인해 주세요.');
+                setWorkflow(null);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchWorkflow();
+    }, [chatId]);
+
+    if (loading) {
+        return (
+            <div className={styles.pageContainer}>
+                <div className={styles.centeredMessage}>
+                    <div className={styles.spinner}></div>
+                    <p>채팅 인터페이스를 불러오는 중입니다...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (error || !workflow) {
+        return (
+            <div className={styles.pageContainer}>
+                <div className={styles.centeredMessage}>
+                    <h2>오류</h2>
+                    <p>{error || '워크플로우를 찾을 수 없습니다.'}</p>
+                    <button onClick={() => router.push('/')} className={styles.homeButton}>
+                        홈으로 돌아가기
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.pageContainer}>
+            <ChatInterface
+                mode="new-workflow"
+                workflow={workflow}
+                onBack={() => {}}
+                hideBackButton={true}
+                existingChatData={null}
+            />
+        </div>
+    );
+};
+
+export default StandaloneChatPage;


### PR DESCRIPTION
### 설명
- 사용자가 워크플로우를 독립된 웹페이지에서 채팅으로 사용할 수 있고, API를 통해 워크플로우를 호출하는 방법을 쉽게 확인할 수 있도록 배포 기능을 도입했습니다.
- 기존에는 배포와 관련된 UI나 가이드가 없어서 외부 사용처에 워크플로우를 적용하는 데 어려움이 있었던 문제를 해결합니다.

### 주요 변경 사항
- 새로운 모드 `deploy` 추가로 배포 전용 화면을 구분하여 제공
- ChatHeader에 배포 버튼 추가 및 배포 모달 오픈 이벤트 연결
- 배포 정보 모달(DeploymentModal) 컴포넌트 구현
  - 웹페이지 탭: 독립된 웹페이지 URL 제공 및 복사 기능
  - API 연동 탭: Python 및 JavaScript 예제 코드 제공
  - 접근성 고려, 포커스 관리 및 ESC 키로 모달 닫기 기능 구현
- 스타일(DeploymentModal.module.scss 및 기존 ChatInterface.module.scss 확장) 추가
- 독립 실행형 배포 페이지(`/chatbot/[chatId]/page.tsx`) 구현
  - URL 파라미터로 워크플로우 ID와 이름을 받아 채팅 인터페이스를 배포 모드로 렌더링
  - 로딩, 오류 처리 UI 추가