### PR TITLE
[수정] Chat 모드에 'deploy' 적용 범위 확장

### DIFF
--- a/src/app/chat/components/ChatArea.tsx
+++ b/src/app/chat/components/ChatArea.tsx
@@ -30,7 +30,7 @@ export const ChatArea: React.FC<ChatAreaProps> = ({
     formatDate,
 }) => {
     // 1. 로딩 상태 처리 (existing 모드 전용)
-    if (mode === 'existing' && loading) {
+    if (mode === 'existing' || mode === 'deploy' && loading) {
         return (
             <div className={styles.chatContainer}>
                 <div className={styles.loadingState}>
@@ -43,7 +43,7 @@ export const ChatArea: React.FC<ChatAreaProps> = ({
 
     // 2. 각 모드에 맞는 컨텐츠 렌더링
     const renderContent = () => {
-        if (mode === 'existing') {
+        if (mode === 'existing' || mode === 'deploy') {
             return ioLogs.length === 0 ? (
                 <EmptyState title="대화 기록이 없습니다">
                     <p>&quot;{workflow.name}&quot; 워크플로우의 이전 대화를 불러올 수 없습니다.</p>

--- a/src/app/chat/components/ChatArea.tsx
+++ b/src/app/chat/components/ChatArea.tsx
@@ -30,7 +30,7 @@ export const ChatArea: React.FC<ChatAreaProps> = ({
     formatDate,
 }) => {
     // 1. 로딩 상태 처리 (existing 모드 전용)
-    if (mode === 'existing' || mode === 'deploy' && loading) {
+    if (mode === 'existing' && loading) {
         return (
             <div className={styles.chatContainer}>
                 <div className={styles.loadingState}>

--- a/src/app/chat/components/ChatInterface.tsx
+++ b/src/app/chat/components/ChatInterface.tsx
@@ -59,7 +59,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, h
                 setLoading(false);
             }
         };
-        if (mode === 'existing' && workflow?.id && existingChatData?.interactionId) {
+        if (mode === 'existing' || mode === 'deploy' && workflow?.id && existingChatData?.interactionId) {
             loadChatLogs();
         }
     }, [mode, existingChatData?.interactionId, workflow.id, workflow.name, existingChatData?.workflowName, existingChatData?.workflowId]);

--- a/src/app/main/components/Settings.tsx
+++ b/src/app/main/components/Settings.tsx
@@ -204,30 +204,6 @@ const Settings: React.FC = () => {
         }
     };
 
-    const renderOpenAIConfig = () => {
-        const config = configs.openai || {};
-        return (
-            <OpenAIConfig
-                config={config}
-                onConfigChange={handleConfigChange}
-                onTestConnection={handleTestConnection}
-                configData={configData}
-            />
-        );
-    };
-
-    const renderVLLMConfig = () => {
-        const config = configs.vllm || {};
-        return (
-            <VLLMConfig
-                config={config}
-                onConfigChange={handleConfigChange}
-                onTestConnection={handleTestConnection}
-                configData={configData}
-            />
-        );
-    };
-
     const renderWorkflowConfig = () => {
         return (
             <WorkflowConfig


### PR DESCRIPTION
### 설명
- 기존에는 'existing' 모드에서만 지원되던 채팅 로딩과 표시 기능을 'deploy' 모드에도 확장하기 위해 변경했습니다.
- 이 변경으로 'deploy' 모드 사용 시에도 기존 대화 기록 표시와 로딩 상태 처리가 정상 동작하여 사용자 경험이 향상됩니다.

### 주요 변경 사항
- `ChatArea` 컴포넌트의 로딩 상태 처리 코드를 'deploy' 모드까지 적용하도록 수정
- `ChatArea` 컴포넌트에서 대화 기록이 없을 때 보여주는 EmptyState를 'deploy' 모드에도 확장
- `ChatInterface` 컴포넌트에서 기존 대화 기록을 불러오는 로직을 'deploy' 모드까지 적용하도록 변경