### PR TITLE
[기능] DeploymentModal에 cURL 탭 추가 및 Payload 편집 기능 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,14 +2,14 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
     async rewrites() {
-    return [
-      {
-        source: '/api/workflow/execute/based_id',
-        
-        destination: `${process.env.NEXT_PUBLIC_BACKEND_HOST}:${process.env.NEXT_PUBLIC_BACKEND_PORT}/api/workflow/execute/based_id`,
-      },
-    ];
-  },
+        return [
+            {
+                source: '/api/workflow/execute/based_id',
+
+                destination: `${process.env.NEXT_PUBLIC_BACKEND_HOST}:${process.env.NEXT_PUBLIC_BACKEND_PORT}/api/workflow/execute/based_id`,
+            },
+        ];
+    },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-    /* config options here */
+    async rewrites() {
+    return [
+      {
+        source: '/api/workflow/execute/based_id',
+        
+        destination: `${process.env.NEXT_PUBLIC_BACKEND_HOST}:${process.env.NEXT_PUBLIC_BACKEND_PORT}/api/workflow/execute/based_id`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/chat/assets/ChatInterface.module.scss
+++ b/src/app/chat/assets/ChatInterface.module.scss
@@ -970,7 +970,72 @@ $white: #ffffff;
     h5 {
       margin-top: 1.5rem;
       margin-bottom: 0.5rem;
+      font-size: 0.9rem;
+      font-weight: 600;
     }
+}
+.payloadTextarea {
+    width: 100%;
+    background: $gray-800;
+    color: $gray-100;
+    border: 1px solid $gray-600;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    font-family: monospace; // 코드용 고정폭 글꼴
+    font-size: 0.875rem;
+    resize: vertical; // 세로 크기만 조절 가능하도록 설정
+    line-height: 1.5;
+
+    &:focus {
+        outline: none;
+        border-color: $primary-blue;
+        box-shadow: 0 0 0 2px rgba($primary-blue, 0.2);
+    }
+}
+
+.codeBlockHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+
+    h5 {
+        margin: 0; /* h5의 기본 마진 제거 */
+        font-size: 0.9rem;
+        font-weight: 600;
+    }
+}
+
+.copyButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background-color: $gray-200;
+    border: 1px solid $gray-300;
+    color: $gray-700;
+    padding: 0.25rem 0.6rem;
+    border-radius: 0.375rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        background-color: $gray-300;
+        border-color: $gray-400;
+    }
+
+    &:active {
+        transform: scale(0.97);
+    }
+}
+
+.curlCommandHeader {
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
 }
 
 // Responsive Design


### PR DESCRIPTION
### 설명
- 기존 DeploymentModal에서 API 호출용 코드 스니펫만 제공하던 부분에 사용자 편집 가능한 cURL 탭을 추가했습니다.
- 사용자에게 직접 cURL 요청 페이로드를 수정할 수 있는 기능을 제공하여, 보다 유연한 API 테스트와 배포가 가능하도록 돕습니다.
- 클립보드 복사 기능도 함께 추가하여 편리성을 개선하였습니다.

### 주요 변경 사항
- `next.config.ts`에서 리라이터(rewrites) 함수 포맷 수정 및 API 경로 리라이트 설정 추가
- SCSS에 cURL 페이로드 편집용 텍스트영역, 코드 블록 헤더, 복사 버튼 스타일 추가
- `DeploymentModal.tsx`에 다음 기능 추가:
  - cURL 탭 UI 및 탭 전환 기능 구현
  - cURL 요청에 포함될 기본 JSON 페이로드 생성 및 상태 관리
  - 사용자 입력에 따른 cURL 명령어 실시간 생성
  - 복사 버튼 및 클립보드 복사 기능(toast 알림 포함) 구현
  - 기존 Python/JavaScript API 코드 영역에 복사 버튼 추가