### PR TITLE
[수정] 내비게이션 링크에 replace 속성 추가하여 라우팅 동작 개선

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -62,7 +62,7 @@ const ForgotPasswordPage = () => {
         </form>
 
         <div className={styles.links}>
-          <Link href="/login">로그인 페이지로 돌아가기</Link>
+          <Link href="/login" replace>로그인 페이지로 돌아가기</Link>
         </div>
       </div>
     </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -51,8 +51,8 @@ const LoginPage = () => {
         </form>
 
         <div className={styles.links}>
-          <Link href="/forgot-password">비밀번호를 잊으셨나요?</Link>
-          <Link href="/signup">회원가입</Link>
+          <Link href="/forgot-password" replace>비밀번호를 잊으셨나요?</Link>
+          <Link href="/signup" replace>회원가입</Link>
         </div>
       </div>
     </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -34,7 +34,7 @@ const SignupPage = () => {
       await registerUser(userData); 
       
       alert('회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.');
-      router.push('/login');
+      return <Link href="/login" replace />;
 
     } catch (err: any) {
       // 3. API 함수에서 던져진 에러를 여기서 잡아 UI에 표시합니다.
@@ -99,7 +99,7 @@ const SignupPage = () => {
         </form>
 
         <div className={styles.links}>
-          <Link href="/login">이미 계정이 있으신가요? 로그인</Link>
+          <Link href="/login" replace>이미 계정이 있으신가요? 로그인</Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 설명
- 페이지 간 이동 시 히스토리 스택에 이전 페이지가 쌓이지 않도록 내비게이션 링크에 `replace` 속성을 적용했습니다.
- 이를 통해 사용자가 뒤로 가기 버튼을 눌렀을 때 불필요한 경로를 돌아가지 않고 자연스러운 네비게이션 경험을 제공할 수 있습니다.
- 기존에는 로그인, 회원가입, 비밀번호 찾기 페이지 링크에서 히스토리 스택이 누적되어 사용자 경험이 다소 불편한 점을 개선합니다.

### 주요 변경 사항
- `forgot-password`, `login`, `signup` 페이지 내 링크에 `replace` 속성 추가
- `signup` 페이지의 회원가입 완료 후 라우팅 방식 변경: `router.push('/login')`에서 `<Link href="/login" replace />` 컴포넌트 반환으로 수정
- 관련 페이지 내 모든 내비게이션 링크에 일관되게 `replace` 속성을 적용하여 라우팅 동작 통일