### PR TITLE
[리팩토링] API 요청을 위한 공통 apiClient 래퍼 도입 및 기존 fetch 호출 대체

### DIFF
--- a/src/app/api/apiClient.js
+++ b/src/app/api/apiClient.js
@@ -1,0 +1,41 @@
+/**
+ * 로컬 스토리지에서 인증 토큰을 가져옵니다.
+ * @returns {string|null}
+ */
+const getToken = () => {
+    return localStorage.getItem('accessToken');
+};
+
+/**
+ * 전역 fetch 래퍼 함수. 모든 API 요청은 이 함수를 통해 이루어집니다.
+ * @param {string} url - 요청을 보낼 URL
+ * @param {object} options - fetch에 전달할 옵션 객체
+ * @returns {Promise<Response>} fetch의 응답(Response) 객체를 담은 프로미스
+ */
+export const apiClient = async (url, options = {}) => {
+    const token = getToken();
+
+    const defaultHeaders = {
+        'Content-Type': 'application/json',
+    };
+
+    if (token) {
+        defaultHeaders['Authorization'] = `Bearer ${token}`;
+    }
+
+    const mergedOptions = {
+        ...options,
+        headers: {
+            ...defaultHeaders,
+            ...options.headers,
+        },
+    };
+
+    const response = await fetch(`${url}`, mergedOptions);
+
+    if (response.status === 401) {
+        console.error('Unauthorized request. Redirecting to login...');
+    }
+
+    return response;
+};

--- a/src/app/api/configAPI.js
+++ b/src/app/api/configAPI.js
@@ -1,6 +1,7 @@
 // Configuration API 호출 함수들을 관리하는 파일
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 /**
  * 백엔드에서 모든 설정 정보를 가져오는 함수
@@ -8,7 +9,7 @@ import { API_BASE_URL } from '@/app/config.js';
  */
 export const fetchAllConfigs = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/app/config/persistent`);
+        const response = await apiClient(`${API_BASE_URL}/app/config/persistent`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -30,7 +31,7 @@ export const fetchAllConfigs = async () => {
  */
 export const updateConfig = async (configName, value) => {
     try {
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/app/config/persistent/${configName}`,
             {
                 method: 'PUT',
@@ -61,7 +62,7 @@ export const updateConfig = async (configName, value) => {
  */
 export const refreshConfigs = async () => {
     try {
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/app/config/persistent/refresh`,
             {
                 method: 'POST',
@@ -139,7 +140,7 @@ export const testConnection = async (category) => {
  */
 export const saveConfigs = async () => {
     try {
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/app/config/persistent/save`,
             {
                 method: 'POST',
@@ -167,7 +168,7 @@ export const saveConfigs = async () => {
  */
 export const fetchAppConfig = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/app/config`);
+        const response = await apiClient(`${API_BASE_URL}/app/config`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/app/api/embeddingAPI.js
+++ b/src/app/api/embeddingAPI.js
@@ -1,6 +1,7 @@
 // RAG API 호출 함수들을 관리하는 파일
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 /**
  * 사용 가능한 임베딩 제공자 목록을 조회하는 함수
@@ -8,7 +9,7 @@ import { API_BASE_URL } from '@/app/config.js';
  */
 export const getEmbeddingProviders = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/providers`);
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/providers`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -29,7 +30,7 @@ export const getEmbeddingProviders = async () => {
  */
 export const testEmbeddingProviders = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/test`);
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/test`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -50,7 +51,7 @@ export const testEmbeddingProviders = async () => {
  */
 export const getEmbeddingStatus = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/status`);
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/status`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -72,7 +73,7 @@ export const getEmbeddingStatus = async () => {
  */
 export const testEmbeddingQuery = async (queryText = "Hello, world!") => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/test-query`, {
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/test-query`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -101,7 +102,7 @@ export const testEmbeddingQuery = async (queryText = "Hello, world!") => {
  */
 export const reloadEmbeddingClient = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/reload`, {
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/reload`, {
             method: 'POST',
         });
 
@@ -125,7 +126,7 @@ export const reloadEmbeddingClient = async () => {
  */
 export const switchEmbeddingProvider = async (newProvider) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/switch-provider`, {
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/switch-provider`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -154,7 +155,7 @@ export const switchEmbeddingProvider = async (newProvider) => {
  */
 export const autoSwitchEmbeddingProvider = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/auto-switch`, {
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/auto-switch`, {
             method: 'POST',
         });
 
@@ -177,7 +178,7 @@ export const autoSwitchEmbeddingProvider = async () => {
  */
 export const getEmbeddingConfigStatus = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/embedding/config-status`);
+        const response = await apiClient(`${API_BASE_URL}/api/embedding/config-status`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -202,7 +203,7 @@ export const getEmbeddingConfigStatus = async () => {
  */
 export const getEmbeddingDebugInfo = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/debug/info`);
+        const response = await apiClient(`${API_BASE_URL}/api/debug/info`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/app/api/interactionAPI.js
+++ b/src/app/api/interactionAPI.js
@@ -1,5 +1,6 @@
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 /**
  * ExecutionMeta 정보들을 리스트 형태로 반환합니다.
@@ -20,7 +21,7 @@ export const listInteractions = async (filters = {}) => {
         if (workflow_id) params.append('workflow_id', workflow_id);
         params.append('limit', limit.toString());
 
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/api/interaction/list?${params}`,
             {
                 method: 'GET',
@@ -74,7 +75,7 @@ export const executeWorkflowNew = async (requestData) => {
 
         devLog.log('Executing new workflow with data:', requestBody);
 
-        const response = await fetch(`${API_BASE_URL}/api/interaction/new`, {
+        const response = await apiClient(`${API_BASE_URL}/api/interaction/new`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/app/api/llmAPI.js
+++ b/src/app/api/llmAPI.js
@@ -1,6 +1,7 @@
 // LLM API 호출 함수들을 관리하는 파일
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 /**
  * LLM 제공자 상태 정보를 가져오는 함수
@@ -8,7 +9,7 @@ import { API_BASE_URL } from '@/app/config.js';
  */
 export const getLLMStatus = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/config/llm/status`);
+        const response = await apiClient(`${API_BASE_URL}/api/config/llm/status`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -34,7 +35,7 @@ export const switchLLMProvider = async (provider) => {
             throw new Error('Invalid provider. Must be "openai", "vllm", or "sgl"');
         }
 
-        const response = await fetch(`${API_BASE_URL}/api/config/llm/switch-provider`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/llm/switch-provider`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -63,7 +64,7 @@ export const switchLLMProvider = async (provider) => {
  */
 export const autoSwitchLLMProvider = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/config/llm/auto-switch`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/llm/auto-switch`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -91,7 +92,7 @@ export const testLLMConnection = async () => {
     try {
         devLog.info('Testing current LLM provider connection...');
 
-        const response = await fetch(`${API_BASE_URL}/api/config/test/llm`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/test/llm`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -121,7 +122,7 @@ export const testOpenAIConnection = async () => {
     try {
         devLog.info('Testing OpenAI connection...');
 
-        const response = await fetch(`${API_BASE_URL}/api/config/test/openai`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/test/openai`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -151,7 +152,7 @@ export const testVLLMConnection = async () => {
     try {
         devLog.info('Testing vLLM connection...');
 
-        const response = await fetch(`${API_BASE_URL}/api/config/test/vllm`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/test/vllm`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -181,7 +182,7 @@ export const testSGLConnection = async () => {
     try {
         devLog.info('Testing SGL connection...');
 
-        const response = await fetch(`${API_BASE_URL}/api/config/test/sgl`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/test/sgl`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -214,7 +215,7 @@ export const validateLLMProvider = async (provider) => {
             throw new Error('Invalid provider. Must be "openai", "vllm", or "sgl"');
         }
 
-        const response = await fetch(`${API_BASE_URL}/api/config/llm/validate/${provider}`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/llm/validate/${provider}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -263,7 +264,7 @@ export const getLLMModels = async (provider) => {
 
         devLog.info(`Fetching models for ${provider}...`);
 
-        const response = await fetch(`${API_BASE_URL}/api/config/llm/models/${provider}`, {
+        const response = await apiClient(`${API_BASE_URL}/api/config/llm/models/${provider}`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/app/api/nodeAPI.js
+++ b/src/app/api/nodeAPI.js
@@ -1,5 +1,6 @@
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 /**
  * @returns {Promise<Array<Object>>} 노드 객체의 배열을 반환하는 프로미스
@@ -7,7 +8,7 @@ import { API_BASE_URL } from '@/app/config.js';
  */
 export const getNodes = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/node/get`);
+        const response = await apiClient(`${API_BASE_URL}/api/node/get`);
 
         if (!response.ok) {
             const errorData = await response.json();
@@ -30,7 +31,7 @@ export const getNodes = async () => {
  */
 export const exportNodes = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/node/export`);
+        const response = await apiClient(`${API_BASE_URL}/api/node/export`);
 
         if (!response.ok) {
             const errorData = await response.json();
@@ -53,7 +54,7 @@ export const exportNodes = async () => {
  */
 export const refreshNodes = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/node/refresh`);
+        const response = await apiClient(`${API_BASE_URL}/api/node/refresh`);
 
         if (!response.ok) {
             const errorData = await response.json();

--- a/src/app/api/retrievalAPI.js
+++ b/src/app/api/retrievalAPI.js
@@ -1,6 +1,7 @@
 // RAG API 호출 함수들을 관리하는 파일
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 // =============================================================================
 // Health Check
@@ -12,7 +13,7 @@ import { API_BASE_URL } from '@/app/config.js';
  */
 export const checkRagHealth = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/health`);
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/health`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -37,7 +38,7 @@ export const checkRagHealth = async () => {
  */
 export const listCollections = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/collections`);
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/collections`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -62,7 +63,7 @@ export const listCollections = async () => {
  */
 export const createCollection = async (collectionName, distance = "Cosine", description = null, metadata = null) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/collections`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/collections`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -95,7 +96,7 @@ export const createCollection = async (collectionName, distance = "Cosine", desc
  */
 export const deleteCollection = async (collectionName) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/collections`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/collections`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json',
@@ -125,7 +126,7 @@ export const deleteCollection = async (collectionName) => {
  */
 export const getCollectionInfo = async (collectionName) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/collections/${collectionName}`);
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/collections/${collectionName}`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -167,7 +168,7 @@ export const uploadDocument = async (file, collectionName, chunkSize = 1000, chu
             formData.append('metadata', JSON.stringify(metadata));
         }
 
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/documents/upload`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/documents/upload`, {
             method: 'POST',
             body: formData,
         });
@@ -196,7 +197,7 @@ export const uploadDocument = async (file, collectionName, chunkSize = 1000, chu
  */
 export const searchDocuments = async (collectionName, queryText, limit = 5, scoreThreshold = 0.7, filter = null) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/documents/search`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/documents/search`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -230,7 +231,7 @@ export const searchDocuments = async (collectionName, queryText, limit = 5, scor
  */
 export const listDocumentsInCollection = async (collectionName) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/collections/${collectionName}/documents`);
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/collections/${collectionName}/documents`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -253,7 +254,7 @@ export const listDocumentsInCollection = async (collectionName) => {
  */
 export const getDocumentDetails = async (collectionName, documentId) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/collections/${collectionName}/documents/${documentId}`);
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/collections/${collectionName}/documents/${documentId}`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -276,7 +277,7 @@ export const getDocumentDetails = async (collectionName, documentId) => {
  */
 export const deleteDocumentFromCollection = async (collectionName, documentId) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/collections/${collectionName}/documents/${documentId}`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/collections/${collectionName}/documents/${documentId}`, {
             method: 'DELETE',
         });
 
@@ -305,7 +306,7 @@ export const deleteDocumentFromCollection = async (collectionName, documentId) =
  */
 export const insertPoints = async (collectionName, points) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/points`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/points`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -337,7 +338,7 @@ export const insertPoints = async (collectionName, points) => {
  */
 export const deletePoints = async (collectionName, pointIds) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/points`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/points`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json',
@@ -372,7 +373,7 @@ export const deletePoints = async (collectionName, pointIds) => {
  */
 export const searchPoints = async (collectionName, queryVector, limit = 10, scoreThreshold = null, filter = null) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/search`, {
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/search`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -411,7 +412,7 @@ export const searchPoints = async (collectionName, queryVector, limit = 10, scor
  */
 export const getRagConfig = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/retrieval/config`);
+        const response = await apiClient(`${API_BASE_URL}/api/retrieval/config`);
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/app/api/userAPI.js
+++ b/src/app/api/userAPI.js
@@ -1,5 +1,6 @@
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 /**
  * 신규 사용자 정보를 백엔드로 전송하여 회원가입을 요청합니다.
@@ -9,7 +10,7 @@ import { API_BASE_URL } from '@/app/config.js';
  */
 export const registerUser = async (userData) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/signup`, {
+        const response = await apiClient(`${API_BASE_URL}/api/signup`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -40,7 +41,7 @@ export const registerUser = async (userData) => {
  */
 export const requestPasswordReset = async (data) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/forgot-password`, {
+        const response = await apiClient(`${API_BASE_URL}/api/forgot-password`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -70,7 +71,7 @@ export const requestPasswordReset = async (data) => {
  */
 export const resetPassword = async (data) => {
     try {
-        const response = await fetch(`/api/reset-password`, {
+        const response = await apiClient(`/api/reset-password`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data),

--- a/src/app/api/workflowAPI.js
+++ b/src/app/api/workflowAPI.js
@@ -1,5 +1,6 @@
 import { devLog } from '@/app/utils/logger';
 import { API_BASE_URL } from '@/app/config.js';
+import { apiClient } from './apiClient';
 
 /**
  * 주어진 워크플로우 데이터를 백엔드로 전송하여 실행합니다.
@@ -9,7 +10,7 @@ import { API_BASE_URL } from '@/app/config.js';
  */
 export const executeWorkflow = async (workflowData) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/workflow/execute`, {
+        const response = await apiClient(`${API_BASE_URL}/api/workflow/execute`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -51,7 +52,7 @@ export const saveWorkflow = async (workflowId, workflowContent) => {
             Object.keys(workflowContent),
         );
 
-        const response = await fetch(`${API_BASE_URL}/api/workflow/save`, {
+        const response = await apiClient(`${API_BASE_URL}/api/workflow/save`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -84,7 +85,7 @@ export const saveWorkflow = async (workflowId, workflowContent) => {
  */
 export const listWorkflows = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/workflow/list`);
+        const response = await apiClient(`${API_BASE_URL}/api/workflow/list`);
 
         if (!response.ok) {
             const errorData = await response.json();
@@ -108,7 +109,7 @@ export const listWorkflows = async () => {
  */
 export const listWorkflowsDetail = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/workflow/list/detail`);
+        const response = await apiClient(`${API_BASE_URL}/api/workflow/list/detail`);
 
         if (!response.ok) {
             const errorData = await response.json();
@@ -138,7 +139,7 @@ export const loadWorkflow = async (workflowId) => {
             ? workflowId.slice(0, -5)
             : workflowId;
 
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/api/workflow/load/${encodeURIComponent(cleanWorkflowId)}`,
         );
 
@@ -165,7 +166,7 @@ export const loadWorkflow = async (workflowId) => {
  */
 export const deleteWorkflow = async (workflowId) => {
     try {
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/api/workflow/delete/${encodeURIComponent(workflowId)}`,
             {
                 method: 'DELETE',
@@ -194,7 +195,7 @@ export const deleteWorkflow = async (workflowId) => {
  */
 export const getWorkflowList = async () => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/workflow/list/detail`, {
+        const response = await apiClient(`${API_BASE_URL}/api/workflow/list/detail`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',
@@ -231,7 +232,7 @@ export const getWorkflowPerformance = async (workflowName, workflowId) => {
             workflow_id: workflowId,
         });
 
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/api/workflow/performance?${params}`,
             {
                 method: 'GET',
@@ -265,7 +266,7 @@ export const getWorkflowPerformance = async (workflowName, workflowId) => {
  */
 export const getWorkflowNodeCounts = async (workflowName, workflowId) => {
     try {
-        const response = await fetch(`${API_BASE_URL}/api/performance/counts/${workflowName}/${workflowId}`);
+        const response = await apiClient(`${API_BASE_URL}/api/performance/counts/${workflowName}/${workflowId}`);
         if (!response.ok) {
             const errorData = await response.json();
             throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
@@ -287,7 +288,7 @@ export const getWorkflowNodeCounts = async (workflowName, workflowId) => {
 export const getPieChartData = async (workflowName, workflowId, limit) => {
     try {
         const params = new URLSearchParams({ limit });
-        const response = await fetch(`${API_BASE_URL}/api/performance/charts/pie/${workflowName}/${workflowId}?${params}`);
+        const response = await apiClient(`${API_BASE_URL}/api/performance/charts/pie/${workflowName}/${workflowId}?${params}`);
         if (!response.ok) {
             const errorData = await response.json();
             throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
@@ -309,7 +310,7 @@ export const getPieChartData = async (workflowName, workflowId, limit) => {
 export const getBarChartData = async (workflowName, workflowId, limit) => {
     try {
         const params = new URLSearchParams({ limit });
-        const response = await fetch(`${API_BASE_URL}/api/performance/charts/bar/${workflowName}/${workflowId}?${params}`);
+        const response = await apiClient(`${API_BASE_URL}/api/performance/charts/bar/${workflowName}/${workflowId}?${params}`);
         if (!response.ok) {
             const errorData = await response.json();
             throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
@@ -331,7 +332,7 @@ export const getBarChartData = async (workflowName, workflowId, limit) => {
 export const getLineChartData = async (workflowName, workflowId, limit) => {
     try {
         const params = new URLSearchParams({ limit });
-        const response = await fetch(`${API_BASE_URL}/api/performance/charts/line/${workflowName}/${workflowId}?${params}`);
+        const response = await apiClient(`${API_BASE_URL}/api/performance/charts/line/${workflowName}/${workflowId}?${params}`);
         if (!response.ok) {
             const errorData = await response.json();
             throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
@@ -359,7 +360,7 @@ export const getWorkflowIOLogs = async (workflowName, workflowId, interactionId 
             interaction_id: interactionId,
         });
 
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/api/workflow/io_logs?${params}`,
             {
                 method: 'GET',
@@ -401,7 +402,7 @@ export const deleteWorkflowIOLogs = async (workflowName, workflowId, interaction
             interaction_id: interactionId,
         });
 
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/api/workflow/io_logs?${params}`,
             {
                 method: 'DELETE',
@@ -453,7 +454,7 @@ export const executeWorkflowById = async (
         if (selectedCollection) {
             requestBody.selected_collection = selectedCollection;
         }
-        const response = await fetch(`${API_BASE_URL}/api/workflow/execute/based_id`, {
+        const response = await apiClient(`${API_BASE_URL}/api/workflow/execute/based_id`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -490,7 +491,7 @@ export const deleteWorkflowPerformance = async (workflowName, workflowId) => {
             workflow_id: workflowId,
         });
 
-        const response = await fetch(
+        const response = await apiClient(
             `${API_BASE_URL}/api/workflow/performance?${params}`,
             {
                 method: 'DELETE',


### PR DESCRIPTION
### 설명
- API 요청 시 중복된 fetch 호출 코드들을 하나의 통합된 apiClient 래퍼 함수로 대체하여 코드의 일관성과 유지보수성을 높이기 위해 이 PR이 필요합니다.
- 인증 토큰 자동 포함, JSON Content-Type 기본 설정, 401 에러 로그 처리 등 공통 기능을 apiClient에 집중시켜 API 호출 로직을 단순화하고 재사용성을 강화합니다.
- 기존에 개별 모듈에서 직접 fetch를 호출하던 부분을 apiClient 호출로 변경하여 코드 중복 및 잠재적 오류 가능성을 줄이고, 향후 API 요청 관련 기능 확장 시 일괄 관리가 가능하도록 개선합니다.

### 주요 변경 사항
- `src/app/api/apiClient.js` 신규 파일 생성
  - 로컬 스토리지에서 인증 토큰을 가져오고, fetch 요청 시 기본 헤더 설정과 토큰을 포함하는 apiClient 래퍼 함수 구현
  - 응답 상태가 401일 경우 로그인 리다이렉트 로직(콘솔에 에러 메시지 출력) 포함

- 기존 API 모듈들(예: configAPI.js, embeddingAPI.js, interactionAPI.js, llmAPI.js, nodeAPI.js, retrievalAPI.js, userAPI.js, workflowAPI.js 등)에서
  - 직접 `fetch` 호출 부분 모두 `apiClient` 호출로 변경
  - `apiClient`를 임포트하여 일관되게 사용하도록 수정

- 각 모듈별 fetch 호출 시 헤더 및 옵션 구조는 기존과 동일하게 유지되면서, 중복된 설정을 제거하고 apiClient로 위임

- API 요청 코드가 간결해지고, 인증관련 헤더 처리가 일괄화되어 인증 관리 및 에러 핸들링이 통합됨