### PR TITLE
[스타일] CompletedWorkflows 헤더 액션을 오른쪽 정렬로 변경

### DIFF
--- a/src/app/main/assets/CompletedWorkflows.module.scss
+++ b/src/app/main/assets/CompletedWorkflows.module.scss
@@ -50,6 +50,8 @@ $white: #ffffff;
   display: flex;
   align-items: center;
   gap: 1rem;
+  margin-left: auto;
+  margin-right: 0;
 }
 
 // Filters

--- a/src/app/main/components/CompletedWorkflows.tsx
+++ b/src/app/main/components/CompletedWorkflows.tsx
@@ -257,10 +257,6 @@ const CompletedWorkflows: React.FC = () => {
         <div className={styles.container}>
             {/* Header with Filters */}
             <div className={styles.header}>
-                <div className={styles.headerInfo}>
-                    <h2>완성된 워크플로우</h2>
-                    <p>저장된 워크플로우를 확인하고 관리하세요.</p>
-                </div>
 
                 <div className={styles.headerActions}>
                     <div className={styles.filters}>


### PR DESCRIPTION
### 설명
- CompletedWorkflows 컴포넌트 내 헤더 부분의 액션 버튼들이 좌측에 배치되어 있어 UI가 어색한 문제를 개선하기 위해 수정했습니다.
- 헤더 액션 영역을 오른쪽으로 정렬하여 사용자 인터페이스를 보다 직관적이고 깔끔하게 만들고자 합니다.

### 주요 변경 사항
- CompletedWorkflows.module.scss에 margin-left: auto;와 margin-right: 0; 스타일 추가로 headerActions를 오른쪽으로 정렬
- CompletedWorkflows.tsx에서 불필요한 headerInfo 영역(제목, 설명 텍스트) 제거하여 헤더 레이아웃 간결화