### PR TITLE
[기능] 모달 열림 시 사이드바 자동 토글 및 사이드바 컨텍스트 추가

### DIFF
--- a/src/app/_common/components/PagesLayoutContent.tsx
+++ b/src/app/_common/components/PagesLayoutContent.tsx
@@ -1,12 +1,27 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, createContext, useContext } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Sidebar from '@/app/_common/components/Sidebar';
 import { getChatSidebarItems, getSettingSidebarItems } from '@/app/_common/components/sidebarConfig';
 import styles from '@/app/main/assets/MainPage.module.scss';
 import { AnimatePresence, motion } from 'framer-motion';
 import { FiChevronRight } from 'react-icons/fi';
+
+interface SidebarContextType {
+    isSidebarOpen: boolean;
+    setIsSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+
+export const useSidebar = () => {
+    const context = useContext(SidebarContext);
+    if (context === undefined) {
+        throw new Error('useSidebar must be used within a SidebarProvider');
+    }
+    return context;
+};
 
 export default function PagesLayoutContent({ children }: { children: React.ReactNode }) {
     const router = useRouter();
@@ -44,36 +59,38 @@ export default function PagesLayoutContent({ children }: { children: React.React
     const chatSidebarItems = getChatSidebarItems();
 
     return (
-        <div className={styles.container}>
-            <AnimatePresence>
-                {isSidebarOpen ? (
-                    <Sidebar 
-                        key="sidebar-panel" 
-                        isOpen={isSidebarOpen}
-                        onToggle={toggleSidebar}
-                        items={settingSidebarItems}
-                        chatItems={chatSidebarItems}
-                        activeItem={activeItem}
-                        onItemClick={handleSidebarItemClick}
-                        initialChatExpanded={pathname === '/chat'}
-                        initialSettingExpanded={pathname === '/main'}
-                    />
-                ) : (
-                    <motion.button
-                        key="sidebar-open-button"
-                        onClick={toggleSidebar}
-                        className={styles.openOnlyBtn}
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                    >
-                        <FiChevronRight />
-                    </motion.button>
-                )}
-            </AnimatePresence>
-            <main className={`${styles.mainContent} ${!isSidebarOpen ? styles.mainContentPushed  : ''}` }>
-                {children}
-            </main>
-        </div>
+        <SidebarContext.Provider value={{ isSidebarOpen, setIsSidebarOpen }}>
+            <div className={styles.container}>
+                <AnimatePresence>
+                    {isSidebarOpen ? (
+                        <Sidebar 
+                            key="sidebar-panel" 
+                            isOpen={isSidebarOpen}
+                            onToggle={toggleSidebar}
+                            items={settingSidebarItems}
+                            chatItems={chatSidebarItems}
+                            activeItem={activeItem}
+                            onItemClick={handleSidebarItemClick}
+                            initialChatExpanded={pathname === '/chat'}
+                            initialSettingExpanded={pathname === '/main'}
+                        />
+                    ) : (
+                        <motion.button
+                            key="sidebar-open-button"
+                            onClick={toggleSidebar}
+                            className={styles.openOnlyBtn}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                        >
+                            <FiChevronRight />
+                        </motion.button>
+                    )}
+                </AnimatePresence>
+                <main className={`${styles.mainContent} ${!isSidebarOpen ? styles.mainContentPushed  : ''}` }>
+                    {children}
+                </main>
+            </div>
+        </SidebarContext.Provider>
     );
 }

--- a/src/app/chat/components/ChatInterface.tsx
+++ b/src/app/chat/components/ChatInterface.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useSidebar } from '@/app/_common/components/PagesLayoutContent';
 import {
     FiSend,
     FiArrowLeft,
@@ -25,6 +26,9 @@ import { generateInteractionId, normalizeWorkflowName } from '@/app/api/interact
 
 
 const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, onChatStarted, hideBackButton = false, existingChatData }) => {
+    const { isSidebarOpen, setIsSidebarOpen } = useSidebar();
+    const sidebarWasOpenRef = useRef<boolean | null>(null);
+    
     const [ioLogs, setIOLogs] = useState<IOLog[]>([]);
     const [loading, setLoading] = useState(false);
     const [executing, setExecuting] = useState(false);
@@ -39,6 +43,24 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, o
 
     const messagesRef = useRef<HTMLDivElement>(null);
     const attachmentButtonRef = useRef<HTMLDivElement>(null);
+
+    const isAnyModalOpen = showDeploymentModal || showCollectionModal;
+    
+        useEffect(() => {
+            if (isAnyModalOpen) {
+                if (sidebarWasOpenRef.current === null) {
+                    sidebarWasOpenRef.current = isSidebarOpen;
+                    if (isSidebarOpen) {
+                        setIsSidebarOpen(false);
+                    }
+                }
+            } else {
+                if (sidebarWasOpenRef.current === true) {
+                    setIsSidebarOpen(true);
+                }
+                sidebarWasOpenRef.current = null;
+            }
+        }, [isAnyModalOpen, isSidebarOpen, setIsSidebarOpen]);
 
     useEffect(() => {
         const loadChatLogs = async () => {

--- a/src/app/main/assets/CompletedWorkflows.module.scss
+++ b/src/app/main/assets/CompletedWorkflows.module.scss
@@ -32,6 +32,7 @@ $white: #ffffff;
 }
 
 .headerInfo {
+  display: flex;
   h2 {
     font-size: 1.875rem;
     font-weight: 700;
@@ -51,7 +52,6 @@ $white: #ffffff;
   align-items: center;
   gap: 1rem;
   margin-left: auto;
-  margin-right: 0;
 }
 
 // Filters

--- a/src/app/main/components/Documents.tsx
+++ b/src/app/main/components/Documents.tsx
@@ -1,6 +1,7 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styles from '../assets/Documents.module.scss';
+import { useSidebar } from '@/app/_common/components/PagesLayoutContent';
 
 import {
     isSupportedFileType,
@@ -102,6 +103,9 @@ interface SearchResponse {
 type ViewMode = 'collections' | 'documents' | 'document-detail';
 
 const Documents: React.FC = () => {
+    const { isSidebarOpen, setIsSidebarOpen } = useSidebar();
+    const sidebarWasOpenRef = useRef<boolean | null>(null);
+
     const [viewMode, setViewMode] = useState<ViewMode>('collections');
     const [collections, setCollections] = useState<Collection[]>([]);
     const [selectedCollection, setSelectedCollection] = useState<Collection | null>(null);
@@ -127,6 +131,25 @@ const Documents: React.FC = () => {
     // 로딩 및 에러 상태
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const isAnyModalOpen = showCreateModal || showDeleteModal || showDeleteDocModal;
+
+    useEffect(() => {
+        if (isAnyModalOpen) {
+            if (sidebarWasOpenRef.current === null) {
+                sidebarWasOpenRef.current = isSidebarOpen;
+                if (isSidebarOpen) {
+                    setIsSidebarOpen(false);
+                }
+            }
+        } else {
+            if (sidebarWasOpenRef.current === true) {
+                setIsSidebarOpen(true);
+            }
+            sidebarWasOpenRef.current = null;
+        }
+    }, [isAnyModalOpen, isSidebarOpen, setIsSidebarOpen]);
+
 
     // 컬렉션 목록 로드
     useEffect(() => {


### PR DESCRIPTION
### 설명
- 모달이 열릴 때 사용자 화면 경험을 개선하기 위해 사이드바가 자동으로 닫히고, 모달이 닫히면 다시 이전 상태대로 복원되도록 기능을 추가했습니다.
- 여러 컴포넌트에서 사이드바 열림 상태를 공유하고 제어할 수 있도록 React Context로 상태 관리를 분리하여 코드의 유지보수성과 재사용성을 높였습니다.
- 이를 통해 UI의 일관성과 사용자 편의성을 향상시키며, 모달과 사이드바가 충돌하는 문제를 해결했습니다.

### 주요 변경 사항
- `PagesLayoutContent` 컴포넌트에 `SidebarContext` 생성 및 `useSidebar` 훅 추가로 사이드바 상태를 전역에서 관리할 수 있게 구현
- `ChatInterface`와 `Documents` 컴포넌트에서 `useSidebar` 훅을 활용하여 모달이 열렸을 때 사이드바가 자동으로 닫히고, 모달 종료 시 원래 상태로 복원되도록 `useEffect` 로직 추가
- `PagesLayoutContent` 내 기존의 사이드바 상태 관련 코드를 Context Provider로 감싸 상태 공유 범위 확장
- 일부 스타일 파일에서 레이아웃 관련 CSS 개선 (예: `CompletedWorkflows.module.scss`의 flexbox 레이아웃 추가)