### PR TITLE
[기능] PagesLayout과 Chat 컴포넌트에 내비게이션 제어 기능 추가

### DIFF
--- a/public/embed-test.html
+++ b/public/embed-test.html
@@ -16,10 +16,10 @@
     <p>오른쪽 아래에 팝업 버튼이 나타나야 합니다.</p>
 
     <script type="module">
-    import {Chatbot} from "http://localhost:3000/chatbot-embed.js"
+    import {Chatbot} from "http://localhost:3001/chatbot-embed.js"
     Chatbot.init({
         chatflowid: "workflow_c88698907b0eb67815f9bd9ac6feb939df6afa86",
-        apiHost: "http://localhost:3000",
+        apiHost: "http://localhost:3001",
         workflowName: "Default Chat Workflow"
     })
 </script>

--- a/src/app/_common/components/PagesLayoutContent.tsx
+++ b/src/app/_common/components/PagesLayoutContent.tsx
@@ -8,20 +8,19 @@ import styles from '@/app/main/assets/MainPage.module.scss';
 import { AnimatePresence, motion } from 'framer-motion';
 import { FiChevronRight } from 'react-icons/fi';
 
-interface SidebarContextType {
+interface PagesLayoutContextType {
     isSidebarOpen: boolean;
     setIsSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    navigateToChatMode: (mode: 'new-chat' | 'current-chat' | 'chat-history') => void;
 }
 
-const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+const PagesLayoutContext = createContext<PagesLayoutContextType | undefined>(undefined);
 
-export const useSidebar = () => {
-    const context = useContext(SidebarContext);
-    if (context === undefined) {
-        throw new Error('useSidebar must be used within a SidebarProvider');
-    }
-    return context;
+export const usePagesLayout = () => {
+    return useContext(PagesLayoutContext);
 };
+
+export const useSidebar = usePagesLayout;
 
 export default function PagesLayoutContent({ children }: { children: React.ReactNode }) {
     const router = useRouter();
@@ -29,6 +28,10 @@ export default function PagesLayoutContent({ children }: { children: React.React
     const searchParams = useSearchParams();
     
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
+    const navigateToChatMode = (mode: 'new-chat' | 'current-chat' | 'chat-history') => {
+        router.replace(`/chat?mode=${mode}`);
+    };
 
     const activeItem = useMemo(() => {
         if (pathname === '/chat') {
@@ -45,9 +48,9 @@ export default function PagesLayoutContent({ children }: { children: React.React
         const mainItems = ['canvas', 'workflows', 'exec-monitor', 'settings', 'config-viewer', 'documents'];
 
         if (chatItems.includes(id)) {
-            router.push(`/chat?mode=${id}`);
+            navigateToChatMode(id as 'new-chat' | 'current-chat' | 'chat-history');
         } else if (mainItems.includes(id)) {
-            router.push(`/main?view=${id}`);
+            router.replace(`/main?view=${id}`);
         }
     };
 
@@ -59,7 +62,7 @@ export default function PagesLayoutContent({ children }: { children: React.React
     const chatSidebarItems = getChatSidebarItems();
 
     return (
-        <SidebarContext.Provider value={{ isSidebarOpen, setIsSidebarOpen }}>
+        <PagesLayoutContext.Provider value={{ isSidebarOpen, setIsSidebarOpen, navigateToChatMode }}>
             <div className={styles.container}>
                 <AnimatePresence>
                     {isSidebarOpen ? (
@@ -91,6 +94,6 @@ export default function PagesLayoutContent({ children }: { children: React.React
                     {children}
                 </main>
             </div>
-        </SidebarContext.Provider>
+        </PagesLayoutContext.Provider>
     );
 }

--- a/src/app/chat/components/ChatPageContent.tsx
+++ b/src/app/chat/components/ChatPageContent.tsx
@@ -4,10 +4,13 @@ import React, { useState, useEffect } from 'react';
 import ChatHistory from '@/app/chat/components/ChatHistory';
 import CurrentChatInterface from '@/app/chat/components/CurrentChatInterface';
 import ChatContent from '@/app/chat/components/ChatContent';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { usePagesLayout } from '@/app/_common/components/PagesLayoutContent';
 
 const ChatPage: React.FC = () => {
     const searchParams = useSearchParams();
+    const router = useRouter();
+    const layoutContext = usePagesLayout();
     const [activeSection, setActiveSection] = useState<string>('new-chat');
 
     useEffect(() => {
@@ -20,11 +23,19 @@ const ChatPage: React.FC = () => {
     }, [searchParams]);
 
     const handleChatSelect = () => {
-        setActiveSection('current-chat');
+        if (layoutContext) {
+            layoutContext.navigateToChatMode('current-chat');
+        } else {
+            router.replace('/chat?mode=current-chat');
+        }
     };
 
     const handleChatStarted = () => {
-        setActiveSection('current-chat');
+        if (layoutContext) {
+            layoutContext.navigateToChatMode('current-chat');
+        } else {
+            router.replace('/chat?mode=current-chat');
+        }
     };
 
     const renderContent = () => {

--- a/src/app/main/components/Documents.tsx
+++ b/src/app/main/components/Documents.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useState, useEffect, useRef } from 'react';
 import styles from '../assets/Documents.module.scss';
-import { useSidebar } from '@/app/_common/components/PagesLayoutContent';
+import { usePagesLayout, useSidebar } from '@/app/_common/components/PagesLayoutContent';
 
 import {
     isSupportedFileType,
@@ -101,7 +101,7 @@ interface SearchResponse {
 type ViewMode = 'collections' | 'documents' | 'document-detail';
 
 const Documents: React.FC = () => {
-    const { isSidebarOpen, setIsSidebarOpen } = useSidebar();
+    const layoutContext = usePagesLayout();
     const sidebarWasOpenRef = useRef<boolean | null>(null);
 
     const [viewMode, setViewMode] = useState<ViewMode>('collections');
@@ -133,20 +133,23 @@ const Documents: React.FC = () => {
     const isAnyModalOpen = showCreateModal || showDeleteModal || showDeleteDocModal;
 
     useEffect(() => {
-        if (isAnyModalOpen) {
-            if (sidebarWasOpenRef.current === null) {
-                sidebarWasOpenRef.current = isSidebarOpen;
-                if (isSidebarOpen) {
-                    setIsSidebarOpen(false);
+        if (layoutContext) {
+            const { isSidebarOpen, setIsSidebarOpen } = layoutContext;
+            if (isAnyModalOpen) {
+                if (sidebarWasOpenRef.current === null) {
+                    sidebarWasOpenRef.current = isSidebarOpen;
+                    if (isSidebarOpen) {
+                        setIsSidebarOpen(false);
+                    }
                 }
+            } else {
+                if (sidebarWasOpenRef.current === true) {
+                    setIsSidebarOpen(true);
+                }
+                sidebarWasOpenRef.current = null;
             }
-        } else {
-            if (sidebarWasOpenRef.current === true) {
-                setIsSidebarOpen(true);
-            }
-            sidebarWasOpenRef.current = null;
         }
-    }, [isAnyModalOpen, isSidebarOpen, setIsSidebarOpen]);
+    }, [isAnyModalOpen, layoutContext]);
 
 
     // 컬렉션 목록 로드


### PR DESCRIPTION
### 설명
- 기존 PagesLayout과 채팅 컴포넌트에서 페이지 이동 관리를 일관되게 하기 위해 내비게이션 제어 함수를 추가하였습니다.
- 이를 통해 URL 쿼리 파라미터 기반의 채팅 모드 전환과 메인 뷰 전환을 보다 명확하고 쉽게 처리할 수 있도록 개선하였습니다.
- 채팅 모드 변경 시 기존에 직접 `router.push` 또는 `router.replace`를 호출하던 방식을 `navigateToChatMode` 함수로 추상화하여 유지보수를 용이하게 합니다.

### 주요 변경 사항
- `PagesLayoutContent` 컴포넌트에 `navigateToChatMode` 함수 추가 및 컨텍스트 확장
- 기존 `SidebarContext`를 `PagesLayoutContext`로 이름 변경 및 기능 확장 (내비게이션 기능 포함)
- `usePagesLayout` 훅 추가 및 기존 `useSidebar` 훅은 `usePagesLayout`을 재사용하도록 변경
- 채팅 및 메인 페이지 이동 시 직접 라우터를 조작하던 부분을 컨텍스트 내 `navigateToChatMode` 함수 호출로 변경
- `ChatInterface`에서 레이아웃 컨텍스트를 사용하여 사이드바 상태 관리 및 모달 표시 시 사이드바 동작을 제어하도록 수정
- `ChatPageContent` 컴포넌트 내 채팅 모드 변경 시 라우터를 직접 사용하는 대신 `navigateToChatMode` 함수 호출 적용
- `public/embed-test.html` 내 챗봇 임베드 스크립트의 API 호스트 주소 변경 (`localhost:3000` → `localhost:3001`)