### PR TITLE
[기능] 캔버스 페이지에 배포 버튼 및 배포 모달 추가

### DIFF
--- a/src/app/canvas/assets/Header.module.scss
+++ b/src/app/canvas/assets/Header.module.scss
@@ -172,6 +172,32 @@
     gap: 16px;
 }
 
+.deployButton {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: #059669;
+    color: #ffffff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+
+    &:hover {
+        background: #047857;
+        transform: translateY(-1px);
+    }
+    &:disabled {
+        background-color: #cccccc;
+        color: #666666;
+        cursor: not-allowed;
+        opacity: 0.7;
+    }
+}
+
 .menuButton {
     background: none;
     border: none;

--- a/src/app/canvas/components/Header.tsx
+++ b/src/app/canvas/components/Header.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import styles from '@/app/canvas/assets/Header.module.scss';
 import { LuPanelRightOpen, LuSave, LuCheck, LuX, LuPencil, LuFileText } from "react-icons/lu";
 import { getWorkflowName, saveWorkflowName } from '@/app/_common/utils/workflowStorage';
+import { FiUpload } from 'react-icons/fi';
 
 // Type definitions
 interface HeaderProps {
@@ -13,6 +14,8 @@ interface HeaderProps {
     onNewWorkflow: () => void;
     workflowName?: string;
     onWorkflowNameChange?: (name: string) => void;
+    onDeploy: () => void;
+    isDeploy?: boolean;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -22,7 +25,9 @@ const Header: React.FC<HeaderProps> = ({
     onExport,
     onNewWorkflow,
     workflowName: externalWorkflowName,
-    onWorkflowNameChange
+    onWorkflowNameChange,
+    onDeploy,
+    isDeploy
 }) => {
     const [workflowName, setWorkflowName] = useState<string>('Workflow');
     const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -131,6 +136,10 @@ const Header: React.FC<HeaderProps> = ({
                 </div>
             </div>
             <div className={styles.rightSection}>
+                <button className={styles.deployButton} onClick={onDeploy} disabled={!isDeploy}>
+                    <FiUpload />
+                    <span>배포</span>
+                </button>
                 <button onClick={onNewWorkflow} className={styles.menuButton} title="New Workflow">
                     <LuFileText />
                 </button>

--- a/src/app/canvas/page.tsx
+++ b/src/app/canvas/page.tsx
@@ -89,6 +89,18 @@ function CanvasPageContent() {
         setIsCanvasReady(true);
     }, []);
 
+    useEffect(() => {
+        setWorkflow({
+            id: workflowId,
+            name: currentWorkflowName,
+            filename: currentWorkflowName,
+            author: 'Unknown',
+            nodeCount: 0,
+            status: 'active' as const,
+        });
+        setIsDeploy(false)
+    }, [workflowId, currentWorkflowName])
+
     // Canvas가 준비되고 노드가 초기화된 후 상태 복원을 위한 useEffect
     useEffect(() => {
         if (!isCanvasReady || !canvasRef.current || !nodesInitialized) {
@@ -324,8 +336,6 @@ function CanvasPageContent() {
     const performNewWorkflow = () => {
         try {
             devLog.log('Starting new workflow...');
-
-            setIsDeploy(false)
 
             // localStorage 데이터 초기화
             startNewWorkflow();

--- a/src/app/chat/components/ChatContent.tsx
+++ b/src/app/chat/components/ChatContent.tsx
@@ -80,6 +80,7 @@ const ChatContentInner: React.FC<ChatContentProps> = ({ onChatStarted }) => {
                             mode={chatMode}
                             workflow={selectedWorkflow}
                             existingChatData={chatMode === 'existing' ? existingChatData : undefined}
+                            firstChat={chatMode === 'existing' ? false : true}
                             onChatStarted={chatMode === 'existing' ? undefined : onChatStarted}
                             onBack={currentView === 'defaultChat' ? () => setCurrentView('welcome') : () => setCurrentView('workflow')}
                         />

--- a/src/app/chat/components/ChatInterface.tsx
+++ b/src/app/chat/components/ChatInterface.tsx
@@ -1,11 +1,8 @@
 'use client';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { usePagesLayout, useSidebar } from '@/app/_common/components/PagesLayoutContent';
+import { usePagesLayout} from '@/app/_common/components/PagesLayoutContent';
 import {
     FiSend,
-    FiArrowLeft,
-    FiMessageSquare,
-    FiClock,
     FiPlus,
     FiFolder,
     FiImage,
@@ -25,7 +22,7 @@ import { DeploymentModal } from './DeploymentModal';
 import { generateInteractionId, normalizeWorkflowName } from '@/app/api/interactionAPI';
 
 
-const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, onChatStarted, hideBackButton = false, existingChatData }) => {
+const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, onChatStarted, hideBackButton = false, firstChat = false, existingChatData }) => {
     const layoutContext = usePagesLayout();
     const sidebarWasOpenRef = useRef<boolean | null>(null);
 
@@ -109,10 +106,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ mode, workflow, onBack, o
                 setLoading(false);
             }
         };
-        if (mode === 'existing' && workflow?.id && existingChatData?.interactionId) {
+        if (mode === 'existing' && workflow?.id && existingChatData?.interactionId && !firstChat) {
             loadChatLogs();
         }
-    }, [mode, existingChatData?.interactionId, workflow.id, workflow.name, existingChatData?.workflowName, existingChatData?.workflowId]);
+    }, [mode, existingChatData?.interactionId, workflow.id, workflow.name, existingChatData?.workflowName, existingChatData?.workflowId, firstChat]);
 
     useEffect(() => {
         scrollToBottom();

--- a/src/app/chat/components/types.tsx
+++ b/src/app/chat/components/types.tsx
@@ -26,6 +26,7 @@ export interface ChatInterfaceProps {
     onChatStarted?: () => void;
     onBack: () => void;
     hideBackButton?: boolean;
+    firstChat?: boolean;
     existingChatData?: {
         interactionId: string;
         workflowId: string;


### PR DESCRIPTION
### 설명
- 캔버스 페이지에서 워크플로우 실행 후, 결과물을 바로 배포할 수 있도록 배포 기능을 추가했습니다.
- 배포 버튼과 배포 모달을 통해 사용자가 워크플로우를 손쉽게 배포할 수 있도록 UI/UX를 개선하고자 합니다.
- 기존에는 배포 기능이 없어 실행 후 별도 과정이 필요했으나, 이번 변경으로 배포 흐름을 간소화하고 작업 효율을 높입니다.

### 주요 변경 사항
- 캔버스 헤더에 배포 버튼(`Deploy`)을 추가하고, 실행 완료 시 배포 가능 상태로 활성화하도록 구현
- 배포 버튼 클릭 시 배포 모달이 열리도록 상태 관리 및 모달 컴포넌트 연동
- workflowId 또는 workflowName 변경 시 상태 초기화 및 배포 가능 여부 관리
- SCSS 스타일에 배포 버튼 스타일 추가 (hover, disabled 상태 포함)
- 채팅 컴포넌트에서 최초 채팅 구분을 위한 `firstChat` 플래그 추가 및 관련 로직 수정
- 캔버스 페이지 내 워크플로우 ID 생성 및 관리 로직 개선, 배포 가능한 상태인지 판단하는 플래그(`isDeploy`) 상태 추가
- 코드 전반에서 배포 기능 관련 이벤트 핸들러 및 상태를 적절히 연결