### PR TITLE
[기능] 모델 훈련 사이드바 및 페이지 추가

### DIFF
--- a/src/app/(page)/model/page.tsx
+++ b/src/app/(page)/model/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React, { Suspense } from 'react';
+import AuthGuard from '@/app/_common/components/AuthGuard';
+import styles from '@/app/main/assets/MainPage.module.scss';
+import ModelPageContent from '@/app/model/components/ModelPageContent';
+
+const LoadingFallback = () => (
+    <div className={styles.container}>
+        <div className={styles.loadingContainer}>
+            <div className={styles.spinner}></div>
+        </div>
+    </div>
+);
+
+const ModelPage: React.FC = () => {
+    return (
+        <AuthGuard fallback={<LoadingFallback />}>
+            <Suspense fallback={<LoadingFallback />}>
+                <ModelPageContent />
+            </Suspense>
+        </AuthGuard>
+    );
+}
+
+export default ModelPage;

--- a/src/app/_common/components/PagesLayoutContent.tsx
+++ b/src/app/_common/components/PagesLayoutContent.tsx
@@ -3,7 +3,8 @@
 import React, { useState, useMemo, createContext, useContext } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Sidebar from '@/app/_common/components/Sidebar';
-import { getChatSidebarItems, getSettingSidebarItems, getWorkflowSidebarItems } from '@/app/_common/components/sidebarConfig';
+import { getChatSidebarItems, getSettingSidebarItems, getTrainSidebarItems, getWorkflowSidebarItems } from '@/app/_common/components/sidebarConfig';
+import { getChatItems, getSettingItems, getWorkflowItems, getTrainItems } from '@/app/_common/components/sidebarConfig';
 import styles from '@/app/main/assets/MainPage.module.scss';
 import { AnimatePresence, motion } from 'framer-motion';
 import { FiChevronRight } from 'react-icons/fi';
@@ -40,17 +41,23 @@ export default function PagesLayoutContent({ children }: { children: React.React
         if (pathname === '/main') {
             return searchParams.get('view') || 'canvas';
         }
+        if (pathname === '/model') {
+            return searchParams.get('view') || 'train';
+        }
         return 'canvas';
     }, [pathname, searchParams]);
 
     const handleSidebarItemClick = (id: string) => {
-        const chatItems = ['new-chat', 'current-chat', 'chat-history'];
-        const mainItems = ['canvas', 'workflows', 'exec-monitor', 'settings', 'config-viewer', 'documents'];
+        const chatItems = getChatItems;
+        const mainItems = [...getWorkflowItems, ...getSettingItems];
+        const trainItems = getTrainItems;
 
         if (chatItems.includes(id)) {
             navigateToChatMode(id as 'new-chat' | 'current-chat' | 'chat-history');
         } else if (mainItems.includes(id)) {
             router.replace(`/main?view=${id}`);
+        } else if (trainItems.includes(id)) {
+            router.replace(`/model?view=${id}`);
         }
     };
 
@@ -61,6 +68,7 @@ export default function PagesLayoutContent({ children }: { children: React.React
     const settingSidebarItems = getSettingSidebarItems();
     const workflowSidebarItems = getWorkflowSidebarItems();
     const chatSidebarItems = getChatSidebarItems();
+    const trainItems = getTrainSidebarItems();
 
     return (
         <PagesLayoutContext.Provider value={{ isSidebarOpen, setIsSidebarOpen, navigateToChatMode }}>
@@ -74,10 +82,12 @@ export default function PagesLayoutContent({ children }: { children: React.React
                             items={settingSidebarItems}
                             workflowItems={workflowSidebarItems}
                             chatItems={chatSidebarItems}
+                            trainItem={trainItems}
                             activeItem={activeItem}
                             onItemClick={handleSidebarItemClick}
                             initialChatExpanded={pathname === '/chat'}
                             initialSettingExpanded={pathname === '/main'}
+                            initialTrainExpanded={pathname === '/train'}
                         />
                     ) : (
                         <motion.button

--- a/src/app/_common/components/Sidebar.tsx
+++ b/src/app/_common/components/Sidebar.tsx
@@ -16,18 +16,21 @@ const Sidebar: React.FC<SidebarProps> = ({
     items,
     workflowItems = [],
     chatItems = [],
+    trainItem = [],
     activeItem,
     onItemClick,
     className = '',
     initialChatExpanded = false,
     initialSettingExpanded = false,
     initialWorkflowExpanded = false,
+    initialTrainExpanded = false,
 }) => {
     const router = useRouter();
     const pathname = usePathname();
     const [isSettingExpanded, setIsSettingExpanded] = useState(initialSettingExpanded);
     const [isChatExpanded, setIsChatExpanded] = useState(initialChatExpanded);
     const [isWorkflowExpanded, setIsWorkflowExpanded] = useState(initialWorkflowExpanded);
+    const [isTrainExpanded, setIsTrainExpanded] = useState(initialTrainExpanded);
 
     // CookieProvider의 useAuth 훅 사용 (AuthGuard에서 이미 인증 검증을 수행하므로 refreshAuth 호출 불필요)
     const { user, isAuthenticated } = useAuth();
@@ -49,6 +52,8 @@ const Sidebar: React.FC<SidebarProps> = ({
     const toggleExpanded = () => setIsSettingExpanded(!isSettingExpanded);
     const toggleChatExpanded = () => setIsChatExpanded(!isChatExpanded);
     const toggleWorkflowExpanded = () => setIsWorkflowExpanded(!isWorkflowExpanded);
+    const toggleTrainExpanded = () => setIsTrainExpanded(!isTrainExpanded);
+
 
     const handleLogoClick = () => {
         router.push('/');
@@ -131,6 +136,34 @@ const Sidebar: React.FC<SidebarProps> = ({
 
                 <nav className={`${styles.sidebarNav} ${isWorkflowExpanded ? styles.expanded : ''}`}>
                     {workflowItems.map((item) => (
+                        <button
+                            key={item.id}
+                            onClick={() => onItemClick(item.id)}
+                            className={`${styles.navItem} ${activeItem === item.id ? styles.active : ''}`}
+                        >
+                            {item.icon}
+                            <div className={styles.navText}>
+                                <div className={styles.navTitle}>{item.title}</div>
+                                <div className={styles.navDescription}>
+                                    {item.description}
+                                </div>
+                            </div>
+                        </button>
+                    ))}
+                </nav>
+
+                <button
+                    className={styles.sidebarToggle}
+                    onClick={toggleTrainExpanded}
+                >
+                    <span>모델</span>
+                    <span className={`${styles.toggleIcon} ${isTrainExpanded ? styles.expanded : ''}`}>
+                        ▼
+                    </span>
+                </button>
+
+                <nav className={`${styles.sidebarNav} ${isTrainExpanded ? styles.expanded : ''}`}>
+                    {trainItem.map((item) => (
                         <button
                             key={item.id}
                             onClick={() => onItemClick(item.id)}

--- a/src/app/_common/components/sidebarConfig.ts
+++ b/src/app/_common/components/sidebarConfig.ts
@@ -8,9 +8,12 @@ import {
     FiClock,
     FiMessageCircle,
     FiFile,
+    FiBarChart2,
 } from 'react-icons/fi';
 import { RiChatSmileAiLine } from "react-icons/ri";
 import { SidebarItem } from '@/app/main/components/types';
+
+export const getChatItems = ['new-chat', 'current-chat', 'chat-history'];
 
 export const getChatSidebarItems = (): SidebarItem[] => [
     {
@@ -33,6 +36,8 @@ export const getChatSidebarItems = (): SidebarItem[] => [
     },
 ];
 
+export const getWorkflowItems = ['canvas', 'workflows', 'documents'];
+
 export const getWorkflowSidebarItems = (): SidebarItem[] => [
     {
         id: 'canvas',
@@ -53,6 +58,37 @@ export const getWorkflowSidebarItems = (): SidebarItem[] => [
         icon: React.createElement(FiFile),
     },
 ];
+
+export const getTrainItems = ['train', 'train-monitor', 'eval', 'model-hub'];
+
+export const getTrainSidebarItems = (): SidebarItem[] => [
+    {
+        id: 'train',
+        title: '모델 훈련',
+        description: '모델 훈련',
+        icon: React.createElement(FiBarChart2),
+    },
+    {
+        id: 'train-monitor',
+        title: '모델 훈련 모니터',
+        description: '모델 훈련 파라미터 모니터링',
+        icon: React.createElement(FiBarChart2),
+    },
+    {
+        id: 'eval',
+        title: '모델 평가',
+        description: '모델 평가',
+        icon: React.createElement(FiBarChart2),
+    },
+    {
+        id: 'model-hub',
+        title: '모델 허브',
+        description: '모델 허브',
+        icon: React.createElement(FiBarChart2),
+    },
+];
+
+export const getSettingItems = ['settings', 'exec-monitor', 'config-viewer'];
 
 export const getSettingSidebarItems = (): SidebarItem[] => [
     {
@@ -81,6 +117,14 @@ export const createItemClickHandler = (router: any) => {
         // 클릭한 섹션을 localStorage에 저장하고 /main으로 이동
         localStorage.setItem('activeSection', itemId);
         router.push('/main');
+    };
+};
+
+export const createTrainItemClickHandler = (router: any) => {
+    return (itemId: string) => {
+        // 클릭한 섹션을 localStorage에 저장하고 /train으로 이동
+        localStorage.setItem('activeSection', itemId);
+        router.push('/train');
     };
 };
 

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -5,6 +5,8 @@
 const host_url = process.env.NEXT_PUBLIC_BACKEND_HOST || 'http://localhost'
 const port = process.env.NEXT_PUBLIC_BACKEND_PORT || null
 
+const metrics = process.env.NEXT_PUBLIC_METRICS_HOST || ''
+
 let BASE_URL = `${host_url}:${port}`
 
 if (!port) {
@@ -28,3 +30,5 @@ export const APP_CONFIG = {
 
 // Export individual configs for convenience
 export const { BASE_URL: API_BASE_URL } = API_CONFIG;
+
+export const METRICS_URL = metrics;

--- a/src/app/main/components/types.ts
+++ b/src/app/main/components/types.ts
@@ -13,12 +13,14 @@ export interface SidebarProps {
     items: SidebarItem[];
     workflowItems?: SidebarItem[];
     chatItems?: SidebarItem[];
+    trainItem?: SidebarItem[];
     activeItem: string;
     onItemClick: (itemId: string) => void;
     className?: string;
     initialChatExpanded?: boolean;
     initialSettingExpanded?: boolean;
     initialWorkflowExpanded?: boolean;
+    initialTrainExpanded?: boolean;
 }
 
 export interface ContentAreaProps {

--- a/src/app/model/components/MetricsPageContent.tsx
+++ b/src/app/model/components/MetricsPageContent.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { METRICS_URL } from '@/app/config';
+
+// 웹사이트의 URL을 정의합니다.
+const websiteUrl = METRICS_URL;
+
+// WebsiteViewer 컴포넌트를 정의합니다.
+const MetricsPageContent: React.FC = () => {
+  return (
+    <div style={{ width: '100%', height: '100vh', overflow: 'hidden' }}>
+      <iframe
+        src={websiteUrl}
+        title="Polar MLflow"
+        style={{
+          width: '100%',
+          height: '100%',
+          border: 'none', // iframe의 테두리를 제거합니다.
+        }}
+        sandbox="allow-scripts allow-same-origin"
+      />
+    </div>
+  );
+};
+
+export default MetricsPageContent;

--- a/src/app/model/components/ModelPageContent.tsx
+++ b/src/app/model/components/ModelPageContent.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import MetricsPageContent from './MetricsPageContent';
+import { getTrainItems } from '@/app/_common/components/sidebarConfig';
+
+const ModelPage: React.FC = () => {
+    const searchParams = useSearchParams();
+    const [activeSection, setActiveSection] = useState<string>('train-monitor');
+
+    useEffect(() => {
+        const view = searchParams.get('view');
+        if (view && getTrainItems.includes(view)) {
+            setActiveSection(view);
+        } else {
+            setActiveSection('train'); // 기본값 설정
+        }
+    }, [searchParams]);
+
+    const renderContent = () => {
+        switch (activeSection) {
+            case 'train-monitor':
+                return <MetricsPageContent/>;
+        }
+    };
+
+    return <>{renderContent()}</>;
+};
+
+export default ModelPage;


### PR DESCRIPTION
### 설명
- 모델 관리 및 훈련 기능을 위해 새로운 사이드바 메뉴와 관련 페이지를 추가했습니다.
- 기존 메인 페이지 구조에 모델 관련 뷰를 포함시키고, 모델 훈련 상태 모니터링을 위한 Metrics 페이지를 iframe으로 내장하여 쉽게 확인할 수 있도록 했습니다.
- 이를 통해 사용자들이 모델 훈련 진행 상황과 평가를 보다 직관적으로 확인하고 접근할 수 있게 됩니다.

### 주요 변경 사항
- `/model` 경로에 접근 가능한 새로운 페이지 `ModelPage` 및 `ModelPageContent` 컴포넌트 추가
- Metrics(모델 훈련 모니터링) 페이지를 iframe으로 동적 로드하는 `MetricsPageContent` 컴포넌트 구현
- 사이드바에 모델 훈련 관련 메뉴(모델 훈련, 훈련 모니터, 평가, 모델 허브) 추가 및 확장 토글 기능 구현
- 기존 사이드바 및 레이아웃 컴포넌트에 모델 훈련 관련 항목 로직 추가
- `sidebarConfig.ts`에 모델 훈련 메뉴 항목 및 ID 리스트, 클릭 핸들러(로컬스토리지 저장 포함) 추가
- 환경 변수로부터 metrics 서버 URL(`NEXT_PUBLIC_METRICS_HOST`)을 받아 `MetricsPageContent`에서 사용하도록 설정