### PR TITLE
[수정] ChatInterface 초기화 로직 간소화 및 분리

### DIFF
--- a/src/app/chat/components/ChatInterface.tsx
+++ b/src/app/chat/components/ChatInterface.tsx
@@ -191,39 +191,37 @@ const ChatInterface: React.FC<NewChatInterfaceProps> = (
     }, [executing, inputMessage, workflow, existingChatData, scrollToBottom]);
 
     useEffect(() => {
-        const initializeChat = async () => {
-            if (initialMessageToExecute && !hasExecutedInitialMessage.current) {
-                hasExecutedInitialMessage.current = true;
+        if (mode === 'existing' && existingChatData?.interactionId && !initialMessageToExecute) {
+            setLoading(true);
+            getWorkflowIOLogs(existingChatData.workflowName, existingChatData.workflowId, existingChatData.interactionId)
+                .then(logs => {
+                    setIOLogs((logs as any).in_out_logs || []);
+                })
+                .catch(err => {
+                    setError('채팅 기록을 불러오는데 실패했습니다.');
+                    setIOLogs([]);
+                })
+                .finally(() => {
+                    setLoading(false);
 
-                setInputMessage(initialMessageToExecute);
-                
-                const newSearchParams = new URLSearchParams(window.location.search);
-                newSearchParams.delete('initial_message');
-                router.replace(`${window.location.pathname}?${newSearchParams.toString()}`, { scroll: false });
-            } 
-            else if (existingChatData?.interactionId) {
-                setLoading(true);
-                
-                getWorkflowIOLogs(existingChatData.workflowName, existingChatData.workflowId, existingChatData.interactionId)
-                    .then(logs => {
-                        setIOLogs((logs as any).in_out_logs || []);
-                    })
-                    .catch(err => {
-                        setError('채팅 기록을 불러오는데 실패했습니다.');
-                        setIOLogs([]);
-                    })
-                    .finally(async () => {
-                        setLoading(false);
-
-                        await executeWorkflow(inputMessage)
-                    });
-            }
-        };
-
-        if (mode === 'existing' && workflow?.id) {
-            initializeChat();
+                    executeWorkflow();
+                });
         }
-    }, [existingChatData, initialMessageToExecute, mode, workflow?.id, router]);
+    }, [mode, existingChatData]);
+
+    useEffect(() => {
+        if (initialMessageToExecute && !hasExecutedInitialMessage.current) {
+            
+            hasExecutedInitialMessage.current = true;
+
+            setInputMessage(initialMessageToExecute);
+
+            const newSearchParams = new URLSearchParams(window.location.search);
+            newSearchParams.delete('initial_message');
+            router.replace(`${window.location.pathname}?${newSearchParams.toString()}`, { scroll: false });
+        }
+    }, [initialMessageToExecute, executeWorkflow, router]);
+
 
 
 


### PR DESCRIPTION
### 설명
- 기존에 복잡하게 얽혀있던 채팅 초기화 로직을 간소화하고, 역할에 따라 useEffect를 분리했습니다.
- 이로 인해 초기 메시지 실행과 기존 채팅 데이터 로드가 명확히 분리되어 가독성과 유지보수성을 향상시켰습니다.
- 초기 메시지 실행 여부와 기존 대화 기록 로드 조건을 명확하게 처리하지 못해 발생할 수 있는 문제를 해결합니다.

### 주요 변경 사항
- 초기 메시지가 있을 경우 해당 메시지를 입력 상태에 설정하고 URL 쿼리에서 `initial_message` 파라미터를 제거하는 로직을 별도의 useEffect로 분리.
- 기존 채팅 데이터가 있을 때 대화 기록을 불러오고 워크플로우를 실행하는 로직을 mode와 existingChatData 의존성에 따라 수행하도록 단순화.
- 불필요한 비동기 함수 감싸기 제거 및 의존성 배열 최적화로 코드 간결화.