### PR TITLE
feat: Style MetricsPageContent with CSS modules

### DIFF
--- a/src/app/model/assets/ModelPage.module.scss
+++ b/src/app/model/assets/ModelPage.module.scss
@@ -1,0 +1,42 @@
+$primary-blue: #2563eb;
+$primary-purple: #7c3aed;
+$primary-green: #059669;
+$gray-50: #f9fafb;
+$gray-100: #f3f4f6;
+$gray-200: #e5e7eb;
+$gray-300: #d1d5db;
+$gray-400: #9ca3af;
+$gray-500: #6b7280;
+$gray-600: #4b5563;
+$gray-700: #374151;
+$gray-800: #1f2937;
+$gray-900: #111827;
+$white: #ffffff;
+
+.modelContainer {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: $white;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+}
+
+.modelSection {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1rem;
+  transition: all 0.5s ease;
+  overflow: hidden;
+  height: 100vh;
+  max-height: 100vh;
+  
+  .container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    height: 100%;
+  }
+}

--- a/src/app/model/components/MetricsPageContent.tsx
+++ b/src/app/model/components/MetricsPageContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { METRICS_URL } from '@/app/config';
+import styles from '@/app/model/assets/ModelPage.module.scss'
 
 // 웹사이트의 URL을 정의합니다.
 const websiteUrl = METRICS_URL;
@@ -7,17 +8,13 @@ const websiteUrl = METRICS_URL;
 // WebsiteViewer 컴포넌트를 정의합니다.
 const MetricsPageContent: React.FC = () => {
   return (
-    <div style={{ width: '100%', height: '100vh', overflow: 'hidden' }}>
-      <iframe
-        src={websiteUrl}
-        title="Polar MLflow"
-        style={{
-          width: '100%',
-          height: '100%',
-          border: 'none', // iframe의 테두리를 제거합니다.
-        }}
-        sandbox="allow-scripts allow-same-origin"
-      />
+    <div className={styles.modelContainer}>
+        <iframe
+          src={websiteUrl}
+          title="Polar MLflow"
+          className={styles.modelSection}
+          sandbox="allow-scripts allow-same-origin"
+        />
     </div>
   );
 };


### PR DESCRIPTION
Refactor MetricsPageContent to use scoped styles from a new ModelPage.module.scss file instead of inline styles. This change improves maintainability and consistency by applying flex layout, background, border radius, and shadow to the container, and setting responsive iframe styling with padding and transitions.