### PR TITLE
chore: Remove unused backend port env variable from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,6 @@ jobs:
         run: |
           cd /home/plateerag
           echo "NEXT_PUBLIC_BACKEND_HOST=${{ secrets.NEXT_PUBLIC_BACKEND_HOST }}" >> .env
-          echo "NEXT_PUBLIC_BACKEND_PORT=${{ secrets.NEXT_PUBLIC_BACKEND_PORT }}" >> .env
           echo "NEXT_PUBLIC_METRICS_HOST=${{ secrets.NEXT_PUBLIC_METRICS_HOST }}" >> .env
 
       - name: Install dependencies & Restart server


### PR DESCRIPTION
Removed NEXT_PUBLIC_BACKEND_PORT from the deployment environment variables as it is no longer required for the application setup. This simplifies the deployment configuration and reduces potential confusion.