### PR TITLE
refactor: Handle backend URL construction with optional port

### DIFF
--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: Create .env file
         run: |
           echo "NEXT_PUBLIC_BACKEND_HOST=${{ secrets.NEXT_PUBLIC_BACKEND_HOST }}" >> .env
-          echo "NEXT_PUBLIC_BACKEND_PORT=${{ secrets.NEXT_PUBLIC_BACKEND_PORT }}" >> .env
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,11 +2,22 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
     async rewrites() {
+
+        const host_url = process.env.NEXT_PUBLIC_BACKEND_HOST || 'http://localhost'
+        const port = process.env.NEXT_PUBLIC_BACKEND_PORT || null
+
+        let BASE_URL = '';
+
+        if (!port) {
+            BASE_URL = host_url;
+        } else {
+            BASE_URL = `${host_url}:${port}`;
+        }
         return [
             {
                 source: '/api/workflow/execute/based_id',
 
-                destination: `${process.env.NEXT_PUBLIC_BACKEND_HOST}:${process.env.NEXT_PUBLIC_BACKEND_PORT}/api/workflow/execute/based_id`,
+                destination: `${BASE_URL}/api/workflow/execute/based_id`,
             },
         ];
     },

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -7,10 +7,12 @@ const port = process.env.NEXT_PUBLIC_BACKEND_PORT || null
 
 const metrics = process.env.NEXT_PUBLIC_METRICS_HOST || ''
 
-let BASE_URL = `${host_url}:${port}`
+let BASE_URL = '';
 
 if (!port) {
-    BASE_URL = host_url
+    BASE_URL = host_url;
+} else {
+    BASE_URL = `${host_url}:${port}`;
 }
 
 console.log(`Backend server running at ${BASE_URL}`);


### PR DESCRIPTION
Refactor environment variable usage to build the backend base URL dynamically, supporting cases where the port may be undefined. This change improves flexibility and prevents malformed URLs by conditionally including the port only when it is set.

- Remove unused port environment variable from GitHub workflow
- Update next.config.ts to construct BASE_URL with optional port
- Adjust src/app/config.js to build BASE_URL similarly and log it correctly