### PR TITLE
fix: Correct isStreamingWorkflow parameter to use workflow ID

### DIFF
--- a/src/app/_common/utils/isStreamingWorkflow.ts
+++ b/src/app/_common/utils/isStreamingWorkflow.ts
@@ -7,8 +7,8 @@ import { Workflow } from "@/app/chat/components/types";
  * @param {object} workflowData - 노드 목록을 포함하는 워크플로우 데이터.
  * @returns {boolean} 스트리밍 endnode가 있으면 true, 그렇지 않으면 false.
  */
-export const isStreamingWorkflow = async (workflow: Workflow) => {
-    const workflowData: WorkflowData = await loadWorkflow(workflow.name);
+export const isStreamingWorkflow = async (workflowId: string) => {
+    const workflowData: WorkflowData = await loadWorkflow(workflowId);
     if (!workflowData || !Array.isArray(workflowData.nodes)) {
         return false;
     }

--- a/src/app/canvas/page.tsx
+++ b/src/app/canvas/page.tsx
@@ -741,7 +741,7 @@ function CanvasPageContent() {
             workflowData = { ...workflowData, workflow_id: workflowId };
             workflowData = { ...workflowData, workflow_name: workflowName };
 
-            const isStreaming = await isStreamingWorkflow(workflowData);
+            const isStreaming = await isStreamingWorkflow(workflowName);
 
             if (isStreaming) {
                 toast.loading('Executing streaming workflow...', { id: toastId });

--- a/src/app/chat/components/ChatInterface.tsx
+++ b/src/app/chat/components/ChatInterface.tsx
@@ -137,7 +137,7 @@ const ChatInterface: React.FC<NewChatInterfaceProps> = (
             if (workflow.name == 'default_mode'){
                 isStreaming = true;
             } else {
-                isStreaming = await isStreamingWorkflow(workflow);
+                isStreaming = await isStreamingWorkflow(workflow.name);
             }
             
             const { interactionId, workflowId, workflowName } = existingChatData || {


### PR DESCRIPTION
Updated isStreamingWorkflow to accept a workflow ID string instead of a Workflow object. Adjusted all calls accordingly to pass the workflow name as the identifier. This ensures proper loading and checking of workflow data for streaming workflows.