### PR TITLE
style: Adjust header margin and logo width on homepage

### DIFF
--- a/src/app/HomePage.module.scss
+++ b/src/app/HomePage.module.scss
@@ -76,13 +76,13 @@
     h1 {
         font-size: 1.75rem;
         font-weight: 700;
-        margin: 0;
+        margin-left: 3px;
         background: linear-gradient(135deg, $gray-900, $gray-700);
         background-clip: text;
         -webkit-background-clip: text;
         -webkit-text-fill-color: transparent;
         letter-spacing: -0.025em;
-        transform: translateY(1.3px) translateX(-3.1px);
+        transform: translateY(1px) translateX(-3.1px);
     }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function HomePage() {
                 <nav className={styles.nav}>
                     <div className={styles.navContent}>
                         <div className={styles.logo}>
-                            <Image src="/simbol.png" alt="XGEN" height={0} width={30}/>
+                            <Image src="/simbol.png" alt="XGEN" height={0} width={26}/>
                             <h1>GEN&nbsp;AI&nbsp;Platform</h1>
                         </div>
                         <div className={styles.navActions}>


### PR DESCRIPTION
- Added left margin to homepage h1 header for better alignment
- Slightly reduced vertical transform on header text for improved positioning
- Decreased logo image width from 30 to 26 pixels for visual balance