### PR TITLE
feat: Remove duplicate quotes in JSON and markdown parsing

### DIFF
--- a/src/app/_common/components/ChatParser.tsx
+++ b/src/app/_common/components/ChatParser.tsx
@@ -52,6 +52,11 @@ const preprocessJsonString = (jsonString: string): string => {
     processed = processed.replace(/\{\{/g, '{').replace(/\}\}/g, '}');
     console.log('🔍 [preprocessJsonString] After brace fix:', processed);
 
+    // 문자열 필드에서 중복된 따옴표 제거
+    processed = processed.replace(/"""([^"]*?)"/g, '"$1"'); // 3개 따옴표 -> 1개
+    processed = processed.replace(/""([^"]*?)"/g, '"$1"');  // 2개 따옴표 -> 1개
+    console.log('🔍 [preprocessJsonString] After quote dedup:', processed);
+
     // 숫자 필드들에 대해 따옴표가 있으면 제거하고, 없으면 그대로 유지
     const numericFields = ['page_number', 'line_start', 'line_end'];
 
@@ -65,11 +70,6 @@ const preprocessJsonString = (jsonString: string): string => {
         processed = processed.replace(malformedNumberPattern, `"${field}": $1`);
     });
     console.log('🔍 [preprocessJsonString] After numeric fix:', processed);
-
-    // 문자열 필드에서 중복된 따옴표 제거 먼저 수행
-    processed = processed.replace(/"""([^"]*?)"/g, '"$1"'); // 3개 따옴표 -> 1개
-    processed = processed.replace(/""([^"]*?)"/g, '"$1"');  // 2개 따옴표 -> 1개
-    console.log('🔍 [preprocessJsonString] After quote dedup:', processed);
 
     console.log('🔍 [preprocessJsonString] Final output:', processed);
 

--- a/src/app/_common/components/ChatParserMarkdown.tsx
+++ b/src/app/_common/components/ChatParserMarkdown.tsx
@@ -121,6 +121,9 @@ export const processInlineMarkdownWithCitations = (
         preprocessedText = preprocessedText.replace(/\{\{/g, '{').replace(/\}\}/g, '}');
         // 숫자 필드 뒤의 잘못된 따옴표 제거
         preprocessedText = preprocessedText.replace(/(\d)"\s*([,}])/g, '$1$2');
+        // 문자열 필드에서 중복 따옴표 정리
+        preprocessedText = preprocessedText.replace(/"""([^"]*?)"/g, '"$1"'); // 3개 따옴표 -> 1개
+        preprocessedText = preprocessedText.replace(/""([^"]*?)"/g, '"$1"');  // 2개 따옴표 -> 1개
 
         console.log('🔍 [findCitations] After basic preprocessing:', preprocessedText);
 


### PR DESCRIPTION
- Add preprocessing step to clean up duplicate quotes (""" or "") in string fields within ChatParser.tsx and ChatParserMarkdown.tsx
- Move duplicate quote removal earlier in ChatParser.tsx to ensure proper order of transformations
- Improve consistency of quote handling to prevent parsing errors in JSON and markdown processing