### PR TITLE
fix: Correct triple closing braces in JSON and markdown parsing

### DIFF
--- a/src/app/_common/components/ChatParser.tsx
+++ b/src/app/_common/components/ChatParser.tsx
@@ -50,6 +50,8 @@ const preprocessJsonString = (jsonString: string): string => {
 
     // 이중 중괄호 {{}} 를 단일 중괄호 {} 로 변경
     processed = processed.replace(/\{\{/g, '{').replace(/\}\}/g, '}');
+    // }}}] 같은 패턴을 }}] 로 정리
+    processed = processed.replace(/\}\}\}/g, '}}');
     console.log('🔍 [preprocessJsonString] After brace fix:', processed);
 
     // 문자열 필드에서 중복된 따옴표 제거

--- a/src/app/_common/components/ChatParserMarkdown.tsx
+++ b/src/app/_common/components/ChatParserMarkdown.tsx
@@ -119,6 +119,8 @@ export const processInlineMarkdownWithCitations = (
         let preprocessedText = inputText;
         // 이중 중괄호를 단일 중괄호로 변환
         preprocessedText = preprocessedText.replace(/\{\{/g, '{').replace(/\}\}/g, '}');
+        // }}}] 같은 패턴을 }}] 로 정리
+        preprocessedText = preprocessedText.replace(/\}\}\}/g, '}}');
         // 숫자 필드 뒤의 잘못된 따옴표 제거
         preprocessedText = preprocessedText.replace(/(\d)"\s*([,}])/g, '$1$2');
         // 문자열 필드에서 중복 따옴표 정리


### PR DESCRIPTION
Add handling to replace triple closing braces `}}}` with double braces `}}` in both ChatParser and ChatParserMarkdown components. This prevents malformed patterns like `}}}]` and ensures consistent brace formatting during preprocessing of JSON strings and inline markdown with citations.