### PR TITLE
[리팩토링] SchemaProviderNode 내부 파라미터 구조 및 컴포넌트 모듈화

### DIFF
--- a/src/app/canvas/components/Node/components/parameters/specialized/SchemaProviderParameter.tsx
+++ b/src/app/canvas/components/Node/components/parameters/specialized/SchemaProviderParameter.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import { LuX } from 'react-icons/lu';
+import styles from '@/app/canvas/assets/Node.module.scss';
+import { createCommonEventHandlers } from '../../../utils/nodeUtils';
+import type { Parameter } from '@/app/canvas/types';
+import { devLog } from '@/app/_common/utils/logger';
+
+interface SchemaProviderParameterProps {
+    id: string;
+    parameter: Parameter;
+    descriptionParameter?: Parameter;
+    nodeId: string;
+    isEditing: boolean;
+    editingValue: string;
+    onParameterChange: (nodeId: string, paramId: string, value: string) => void;
+    onStartEdit: () => void;
+    onChangeEdit: (value: string) => void;
+    onSubmitEdit: () => void;
+    onCancelEdit: () => void;
+    onParameterDelete?: (nodeId: string, paramId: string) => void;
+    onClearSelection?: () => void;
+    onOpenNodeModal?: (nodeId: string, paramId: string, paramName: string, value: string) => void;
+    isPreview?: boolean;
+}
+
+export const SchemaProviderParameter: React.FC<SchemaProviderParameterProps> = ({
+    id,
+    parameter,
+    descriptionParameter,
+    nodeId,
+    isEditing,
+    editingValue,
+    onParameterChange,
+    onStartEdit,
+    onChangeEdit,
+    onSubmitEdit,
+    onCancelEdit,
+    onParameterDelete,
+    onClearSelection,
+    onOpenNodeModal,
+    isPreview = false
+}) => {
+    const eventHandlers = createCommonEventHandlers(onClearSelection);
+
+    const handleValueChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const value = e.target.value;
+        if (value === undefined || value === null) return;
+
+        if (typeof onParameterChange === 'function') {
+            onParameterChange(nodeId, parameter.id, value);
+        }
+    };
+
+    const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (!descriptionParameter) return;
+
+        const value = e.target.value;
+        if (value === undefined || value === null) return;
+
+        if (typeof onParameterChange === 'function') {
+            onParameterChange(nodeId, descriptionParameter.id, value);
+        }
+    };
+
+    const handleNameInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        onChangeEdit(e.target.value);
+    };
+
+    const handleNameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            onSubmitEdit();
+        } else if (e.key === 'Escape') {
+            onCancelEdit();
+        }
+        e.stopPropagation();
+    };
+
+    const handleNameBlur = () => {
+        onSubmitEdit();
+    };
+
+    // Render main value input (select or input based on options)
+    const renderValueInput = () => {
+        const effectiveOptions = parameter.options || [];
+        
+        if (effectiveOptions.length > 0) {
+            return (
+                <select
+                    value={parameter.value !== undefined && parameter.value !== null ? parameter.value.toString() : ''}
+                    onChange={handleValueChange}
+                    {...eventHandlers}
+                    className={`${styles.paramSelect} paramSelect`}
+                >
+                    <option value="">-- Select --</option>
+                    {effectiveOptions.map((option, index) => (
+                        <option key={index} value={option.value}>
+                            {option.label || option.value}
+                        </option>
+                    ))}
+                </select>
+            );
+        } else {
+            return (
+                <input
+                    type="text"
+                    value={parameter.value !== undefined && parameter.value !== null ? parameter.value.toString() : ''}
+                    onChange={handleValueChange}
+                    {...eventHandlers}
+                    draggable={false}
+                    className={`${styles.paramInput} paramInput`}
+                    placeholder="Value"
+                />
+            );
+        }
+    };
+
+    // Render description input
+    const renderDescriptionInput = () => {
+        if (!descriptionParameter) return null;
+
+        if (descriptionParameter.expandable) {
+            return (
+                <div className={styles.expandableWrapper}>
+                    <input
+                        type="text"
+                        value={descriptionParameter.value?.toString() || ''}
+                        onChange={handleDescriptionChange}
+                        onMouseDown={(e) => {
+                            devLog.log('expandable input onMouseDown');
+                            e.stopPropagation();
+                        }}
+                        onClick={(e) => {
+                            devLog.log('expandable input onClick');
+                            e.stopPropagation();
+                        }}
+                        onFocus={(e) => {
+                            devLog.log('expandable input onFocus');
+                            e.stopPropagation();
+                            if (onClearSelection) {
+                                onClearSelection();
+                            }
+                        }}
+                        onKeyDown={(e) => {
+                            e.stopPropagation();
+                        }}
+                        onDragStart={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }}
+                        draggable={false}
+                        className={`${styles.paramInput} paramInput`}
+                        placeholder="Description"
+                        style={{ marginTop: '4px' }}
+                    />
+                    <button
+                        className={styles.expandButton}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            if (onOpenNodeModal) {
+                                onOpenNodeModal(nodeId, descriptionParameter.id, descriptionParameter.name, String(descriptionParameter.value || ''));
+                            }
+                        }}
+                        type="button"
+                        title="Expand to edit"
+                        style={{ marginTop: '4px' }}
+                    >
+                        ⧉
+                    </button>
+                </div>
+            );
+        } else {
+            return (
+                <input
+                    type="text"
+                    value={descriptionParameter.value?.toString() || ''}
+                    onChange={handleDescriptionChange}
+                    {...eventHandlers}
+                    draggable={false}
+                    className={`${styles.paramInput} paramInput`}
+                    placeholder="Description"
+                    style={{ marginTop: '4px' }}
+                />
+            );
+        }
+    };
+
+    return (
+        <>
+            {/* Parameter Name (editable) */}
+            <span className={`${styles.paramKey} ${parameter.required ? styles.required : ''}`}>
+                {isEditing ? (
+                    <input
+                        type="text"
+                        value={editingValue}
+                        onChange={handleNameInputChange}
+                        onKeyDown={handleNameKeyDown}
+                        onBlur={handleNameBlur}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        onClick={(e) => e.stopPropagation()}
+                        onFocus={(e) => {
+                            e.stopPropagation();
+                            if (onClearSelection) {
+                                onClearSelection();
+                            }
+                        }}
+                        onDragStart={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }}
+                        draggable={false}
+                        className={styles.nameInput}
+                        autoFocus
+                    />
+                ) : (
+                    <span
+                        onClick={onStartEdit}
+                        className={styles.nodeName}
+                        style={{ cursor: isPreview ? 'default' : 'pointer' }}
+                    >
+                        {parameter.name && parameter.name.toString().trim() ? parameter.name : parameter.id}
+                    </span>
+                )}
+                
+                {/* Delete button for added parameters */}
+                {parameter.is_added && !isPreview && onParameterDelete && (
+                    <button
+                        className={styles.deleteParameterButton}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onParameterDelete(nodeId, parameter.id);
+                        }}
+                        type="button"
+                        title="Delete parameter"
+                    >
+                        <LuX />
+                    </button>
+                )}
+            </span>
+
+            {/* Double Input Wrapper: Value + Description */}
+            <div className={styles.doubleInputWrapper || `${styles.paramInput} doubleInputWrapper`}>
+                {renderValueInput()}
+                {renderDescriptionInput()}
+            </div>
+        </>
+    );
+};

--- a/src/app/canvas/components/Node/components/specialized/SchemaProviderNodeParameters.tsx
+++ b/src/app/canvas/components/Node/components/specialized/SchemaProviderNodeParameters.tsx
@@ -1,0 +1,247 @@
+import React, { useState } from 'react';
+import { LuPlus } from 'react-icons/lu';
+import styles from '@/app/canvas/assets/Node.module.scss';
+import { separateParameters } from '../../utils/parameterUtils';
+import { useParameterEditing } from '../../hooks/useParameterEditing';
+import type { NodeParametersProps, Parameter } from '@/app/canvas/types';
+import { SchemaProviderParameter } from '../parameters/specialized/SchemaProviderParameter';
+
+export const SchemaProviderNodeParameters: React.FC<NodeParametersProps> = ({
+    nodeId,
+    parameters,
+    isPreview = false,
+    onParameterChange,
+    onParameterNameChange,
+    onParameterAdd,
+    onParameterDelete,
+    onClearSelection,
+    onOpenNodeModal,
+    showAdvanced,
+    onToggleAdvanced
+}) => {
+    const [hoveredParam, setHoveredParam] = useState<string | null>(null);
+    
+    const { basicParameters, advancedParameters, hasAdvancedParams } = separateParameters(parameters);
+    const paramEditingHook = useParameterEditing();
+
+    // Handle custom parameter addition for SchemaProvider
+    const handleAddCustomParameter = (): void => {
+        if (isPreview || !onParameterAdd) return;
+
+        const randomSuffix = Math.random().toString(36).substring(2, 12).padEnd(10, '0');
+        const uniqueId = `key_${randomSuffix}`;
+
+        // Main parameter
+        const mainParameter: Parameter = {
+            id: uniqueId,
+            name: "**kwargs",
+            type: "STR",
+            value: "value",
+            handle_id: true,
+            is_added: true,
+            options: [
+                { value: 'str', label: 'STRING'},
+                { value: 'int', label: 'INTEGER'},
+                { value: 'float', label: 'FLOAT'},
+                { value: 'bool', label: 'BOOLEAN' }
+            ]
+        };
+
+        // Description parameter
+        const descriptionParameter: Parameter = {
+            id: `${uniqueId}_description`,
+            name: "**kwargs_description",
+            type: "STR",
+            value: "description",
+            handle_id: false,
+            is_added: true,
+            expandable: true,
+        };
+
+        onParameterAdd(nodeId, mainParameter);
+        onParameterAdd(nodeId, descriptionParameter);
+    };
+
+    // Handle parameter deletion for SchemaProvider (with linked description)
+    const handleDeleteParameter = (paramId: string): void => {
+        if (isPreview || !onParameterDelete) return;
+
+        onParameterDelete(nodeId, paramId);
+
+        // Delete linked description parameter
+        const param = parameters?.find(p => p.id === paramId);
+        if (param && param.handle_id && param.is_added) {
+            const descriptionParamId = `${paramId}_description`;
+            const descriptionParam = parameters?.find(p => p.id === descriptionParamId);
+            if (descriptionParam) {
+                onParameterDelete(nodeId, descriptionParamId);
+            }
+        }
+    };
+
+    // Enhanced parameter name change handler for SchemaProvider
+    const handleParameterNameChange = (nodeId: string, paramId: string, newName: string): void => {
+        if (!onParameterNameChange) return;
+
+        // Update main parameter name
+        onParameterNameChange(nodeId, paramId, newName);
+
+        // Update linked description parameter name
+        const param = parameters?.find(p => p.id === paramId);
+        if (param && param.handle_id && param.is_added) {
+            const descriptionParamId = `${paramId}_description`;
+            const descriptionParamName = `${newName}_description`;
+            const descriptionParam = parameters?.find(p => p.id === descriptionParamId);
+            
+            if (descriptionParam && onParameterNameChange) {
+                onParameterNameChange(nodeId, descriptionParamId, descriptionParamName);
+            }
+        }
+    };
+
+    const renderParameter = (param: Parameter) => {
+        const paramKey = `${nodeId}-${param.id}`;
+        
+        // Hide description parameters (they're handled by main parameters)
+        if (param.is_added && param.id.endsWith('_description') && !param.handle_id) {
+            return null;
+        }
+
+        // Find linked description parameter for handle_id parameters
+        const descriptionParam = param.is_added && param.handle_id
+            ? parameters?.find(p => p.id === `${param.id}_description`)
+            : undefined;
+
+        // Handle SchemaProvider specific parameters (handle_id params with description)
+        if (param.handle_id === true && param.is_added) {
+            const isEditing = paramEditingHook.editingHandleParams[paramKey] || false;
+            const editingValue = paramEditingHook.editingHandleValues[paramKey] || 
+                (param.name && param.name.toString().trim()) || param.id;
+
+            return (
+                <div key={param.id} className={`${styles.param} param`}>
+                    <SchemaProviderParameter
+                        id={param.id}
+                        parameter={param}
+                        descriptionParameter={descriptionParam}
+                        nodeId={nodeId}
+                        isEditing={isEditing}
+                        editingValue={editingValue}
+                        onParameterChange={onParameterChange}
+                        onStartEdit={() => paramEditingHook.handleHandleParamClick(param, nodeId)}
+                        onChangeEdit={(value) => {
+                            const event = { target: { value } } as React.ChangeEvent<HTMLInputElement>;
+                            paramEditingHook.handleHandleParamChange(event, param, nodeId);
+                        }}
+                        onSubmitEdit={() => paramEditingHook.handleHandleParamSubmit(param, nodeId, handleParameterNameChange)}
+                        onCancelEdit={() => paramEditingHook.handleHandleParamCancel(param, nodeId)}
+                        onParameterDelete={handleDeleteParameter}
+                        onClearSelection={onClearSelection}
+                        onOpenNodeModal={onOpenNodeModal}
+                        isPreview={isPreview}
+                    />
+                </div>
+            );
+        }
+
+        // Regular parameters (non-specialized)
+        return (
+            <div key={param.id} className={`${styles.param} param`}>
+                <span className={`${styles.paramKey} ${param.required ? styles.required : ''}`}>
+                    {param.description && param.description.trim() !== '' && (
+                        <div
+                            className={styles.infoIcon}
+                            onMouseEnter={() => setHoveredParam(param.id)}
+                            onMouseLeave={() => setHoveredParam(null)}
+                        >
+                            ?
+                            {hoveredParam === param.id && (
+                                <div className={styles.tooltip}>
+                                    {param.description}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                    {param.name}
+                </span>
+                
+                {/* Basic parameter input - could be enhanced with parameter type detection */}
+                <input
+                    type="text"
+                    value={param.value !== undefined && param.value !== null ? param.value.toString() : ''}
+                    onChange={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const value = e.target.value;
+                        if (typeof onParameterChange === 'function') {
+                            onParameterChange(nodeId, param.id, value);
+                        }
+                    }}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                    onFocus={(e) => {
+                        e.stopPropagation();
+                        if (onClearSelection) {
+                            onClearSelection();
+                        }
+                    }}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    onDragStart={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                    }}
+                    draggable={false}
+                    className={`${styles.paramInput} paramInput`}
+                />
+            </div>
+        );
+    };
+
+    if (!parameters || parameters.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className={styles.paramSection}>
+            <div className={styles.sectionHeader}>
+                <span>PARAMETER</span>
+                {!isPreview && onParameterAdd && (
+                    <button
+                        className={styles.addParameterButton}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            handleAddCustomParameter();
+                        }}
+                        type="button"
+                        title="Add custom parameter"
+                    >
+                        <LuPlus />
+                    </button>
+                )}
+            </div>
+            
+            {/* Basic Parameters */}
+            {basicParameters.map(param => renderParameter(param))}
+            
+            {/* Advanced Parameters */}
+            {hasAdvancedParams && (
+                <div className={styles.advancedParams}>
+                    <div 
+                        className={styles.advancedHeader} 
+                        onClick={onToggleAdvanced}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                onToggleAdvanced(e as any);
+                            }
+                        }}
+                        role="button"
+                        tabIndex={0}
+                    >
+                        <span>Advanced {showAdvanced ? '▲' : '▼'}</span>
+                    </div>
+                    {showAdvanced && advancedParameters.map(param => renderParameter(param))}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/app/canvas/components/SpecialNode/SchemaProviderNode.tsx
+++ b/src/app/canvas/components/SpecialNode/SchemaProviderNode.tsx
@@ -4,7 +4,6 @@ import type { NodeProps } from '@/app/canvas/types';
 import { useNodeEditing } from '../Node/hooks/useNodeEditing';
 import { 
     hasInputsAndOutputs, 
-    hasParameters, 
     getNodeContainerClasses,
     getNodeContainerStyles
 } from '../Node/utils/nodeUtils';
@@ -86,7 +85,6 @@ const SchemaProviderNode: React.FC<NodeProps> = ({
 
     // Utility calculations
     const { hasIO } = hasInputsAndOutputs(inputs, outputs);
-    const hasParams = hasParameters(parameters);
 
     // Node container classes and styles
     const nodeClasses = getNodeContainerClasses(isSelected, isPreview, isPredicted, styles.node);
@@ -138,7 +136,7 @@ const SchemaProviderNode: React.FC<NodeProps> = ({
                 )}
 
                 {/* Parameters */}
-                {hasParams && !isPredicted && (
+                {!isPredicted && (
                     <>
                         {hasIO && <div className={styles.divider}></div>}
                         <SchemaProviderNodeParameters

--- a/src/app/canvas/components/SpecialNode/SchemaProviderNode.tsx
+++ b/src/app/canvas/components/SpecialNode/SchemaProviderNode.tsx
@@ -1,13 +1,18 @@
-import React, { memo, useState, useEffect, ChangeEvent, KeyboardEvent } from 'react';
+import React, { memo, useState } from 'react';
 import styles from '@/app/canvas/assets/Node.module.scss';
-import { devLog } from '@/app/_common/utils/logger';
-import { fetchParameterOptions } from '@/app/api/parameterApi';
-import { LuRefreshCw, LuPlus, LuX } from 'react-icons/lu';
-import type {
-    Parameter,
-    NodeProps,
-    ParameterOption
-} from '@/app/canvas/types';
+import type { NodeProps } from '@/app/canvas/types';
+import { useNodeEditing } from '../Node/hooks/useNodeEditing';
+import { 
+    hasInputsAndOutputs, 
+    hasParameters, 
+    getNodeContainerClasses,
+    getNodeContainerStyles
+} from '../Node/utils/nodeUtils';
+
+// Components
+import { NodeHeader } from '../Node/components/NodeHeader';
+import { NodePorts } from '../Node/components/NodePorts';
+import { SchemaProviderNodeParameters } from '../Node/components/specialized/SchemaProviderNodeParameters';
 
 const SchemaProviderNode: React.FC<NodeProps> = ({
     id,
@@ -27,824 +32,134 @@ const SchemaProviderNode: React.FC<NodeProps> = ({
     onParameterAdd,
     onParameterDelete,
     onClearSelection,
-    onOpenNodeModal
+    isPredicted = false,
+    predictedOpacity = 1.0,
+    onPredictedNodeHover,
+    onPredictedNodeClick,
+    onOpenNodeModal,
+    onSynchronizeSchema,
+    currentNodes = [],
+    currentEdges = []
 }) => {
     const { nodeName, inputs, parameters, outputs, functionId } = data;
     const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
-    const [isEditingName, setIsEditingName] = useState<boolean>(false);
-    const [editingName, setEditingName] = useState<string>(nodeName);
-    const [hoveredParam, setHoveredParam] = useState<string | null>(null);
-    const [editingHandleParams, setEditingHandleParams] = useState<Record<string, boolean>>({});
-    const [editingHandleValues, setEditingHandleValues] = useState<Record<string, string>>({});
 
-    useEffect(() => {
-        setEditingName(nodeName);
-    }, [nodeName]);
+    // Custom hooks
+    const nodeEditingHook = useNodeEditing(nodeName);
 
-    // Node name editing functions
-    const handleNameDoubleClick = (e: React.MouseEvent): void => {
-        if (isPreview) return;
-        e.stopPropagation();
-        setIsEditingName(true);
-        setEditingName(nodeName);
-    };
-
-    const handleNameChange = (e: ChangeEvent<HTMLInputElement>): void => {
-        setEditingName(e.target.value);
-    };
-
-    const handleNameKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
-        if (e.key === 'Enter') {
-            handleNameSubmit();
-        } else if (e.key === 'Escape') {
-            handleNameCancel();
-        }
-        e.stopPropagation();
-    };
-
-    const handleNameSubmit = (): void => {
-        const trimmedName = editingName.trim();
-        if (trimmedName && trimmedName !== nodeName && onNodeNameChange) {
-            onNodeNameChange(id, trimmedName);
-        } else {
-            // Restore original value if no changes or empty string
-            setEditingName(nodeName);
-        }
-        setIsEditingName(false);
-    };
-
-    const handleNameCancel = (): void => {
-        setEditingName(nodeName);
-        setIsEditingName(false);
-    };
-
-    const handleNameBlur = (): void => {
-        handleNameSubmit();
-    };
-
-    const handleHandleParamClick = (param: Parameter): void => {
-        if (isPreview || !param.handle_id) return;
-        const paramKey = `${id}-${param.id}`;
-        setEditingHandleParams(prev => ({ ...prev, [paramKey]: true }));
-        setEditingHandleValues(prev => ({
-            ...prev,
-            [paramKey]: (param.name && param.name.toString().trim()) || param.id
-        }));
-    };
-
-    const handleHandleParamChange = (e: ChangeEvent<HTMLInputElement>, param: Parameter): void => {
-        const paramKey = `${id}-${param.id}`;
-        setEditingHandleValues(prev => ({ ...prev, [paramKey]: e.target.value }));
-    };
-
-    const handleHandleParamKeyDown = (e: KeyboardEvent<HTMLInputElement>, param: Parameter): void => {
-        if (e.key === 'Enter') {
-            handleHandleParamSubmit(param);
-        } else if (e.key === 'Escape') {
-            handleHandleParamCancel(param);
-        }
-        e.stopPropagation();
-    };
-
-    const handleHandleParamSubmit = (param: Parameter): void => {
-        const paramKey = `${id}-${param.id}`;
-        const trimmedValue = editingHandleValues[paramKey]?.trim() || '';
-        const finalValue = trimmedValue || param.id; // placeholder를 key(param.id)로 설정
-
-        if (finalValue !== param.name && onParameterNameChange) {
-            // 메인 파라미터의 name을 변경
-            onParameterNameChange(id, param.id, finalValue);
-
-            // SchemaProviderNode의 특별한 로직: 연동된 description 파라미터도 함께 업데이트
-            if (param.handle_id && param.is_added) {
-                const descriptionParamId = `${param.id}_description`;
-                const descriptionParamName = `${finalValue}_description`;
-
-                // description 파라미터가 존재하는지 확인하고 업데이트
-                const descriptionParam = parameters?.find(p => p.id === descriptionParamId);
-                if (descriptionParam && onParameterNameChange) {
-                    onParameterNameChange(id, descriptionParamId, descriptionParamName);
-                }
-            }
-        }
-
-        setEditingHandleParams(prev => ({ ...prev, [paramKey]: false }));
-    };
-
-    const handleHandleParamCancel = (param: Parameter): void => {
-        const paramKey = `${id}-${param.id}`;
-        setEditingHandleValues(prev => ({
-            ...prev,
-            [paramKey]: (param.name && param.name.toString().trim()) || param.id
-        }));
-        setEditingHandleParams(prev => ({ ...prev, [paramKey]: false }));
-    };
-
-    const handleHandleParamBlur = (param: Parameter): void => {
-        handleHandleParamSubmit(param);
-    };
-
-    const handleAddCustomParameter = (): void => {
-        if (isPreview || !onParameterAdd) return;
-
-        // 임의의 10자리 값 생성
-        const randomSuffix = Math.random().toString(36).substring(2, 12).padEnd(10, '0');
-        const uniqueId = `key_${randomSuffix}`;
-
-        // 첫 번째 파라미터 (메인 파라미터)
-        const mainParameter: Parameter = {
-            id: uniqueId,
-            name: "**kwargs",
-            type: "STR",
-            value: "value",
-            handle_id: true,
-            is_added: true,
-            options: [{ value: 'str', label: 'STRING'}, { value: 'int', label: 'INTEGER'}, { value: 'float', label: 'FLOAT'}, { value: 'bool', label: 'BOOLEAN' }]
-        };
-
-        // 두 번째 파라미터 (description 파라미터)
-        const descriptionParameter: Parameter = {
-            id: `${uniqueId}_description`,
-            name: "**kwargs_description",
-            type: "STR",
-            value: "description",
-            handle_id: false,
-            is_added: true,
-            expandable: true,
-        };
-
-        // 두 파라미터를 순차적으로 추가
-        onParameterAdd(id, mainParameter);
-        onParameterAdd(id, descriptionParameter);
-    };    // 파라미터 삭제 함수 (SchemaProviderNode용 - 연동된 파라미터도 함께 삭제)
-    const handleDeleteParameter = (paramId: string): void => {
-        if (isPreview || !onParameterDelete) return;
-
-        // 메인 파라미터 삭제
-        onParameterDelete(id, paramId);
-
-        // SchemaProviderNode 특별 로직: 연동된 description 파라미터도 함께 삭제
-        const param = parameters?.find(p => p.id === paramId);
-        if (param && param.handle_id && param.is_added) {
-            const descriptionParamId = `${paramId}_description`;
-            const descriptionParam = parameters?.find(p => p.id === descriptionParamId);
-            if (descriptionParam) {
-                onParameterDelete(id, descriptionParamId);
-            }
-        }
-    };
-
-
-    const numberList = ['INT', 'FLOAT', 'NUMBER', 'INTEGER'];
-
-    // Separate parameters into basic/advanced
-    const basicParameters = parameters?.filter(param => !param.optional) || [];
-    const advancedParameters = parameters?.filter(param => param.optional) || [];
-    const hasAdvancedParams = advancedParameters.length > 0;
-
-    const toggleAdvanced = (e: React.MouseEvent): void => {
-        e.stopPropagation();
-        setShowAdvanced(prev => !prev);
-    };
-
-    // Parameter rendering function
-    const renderParameter = (param: Parameter) => {
-        const paramKey = `${id}-${param.id}`;
-        const isApiParam = param.is_api && param.api_name;
-        const isHandleParam = param.handle_id === true;
-        const isEditingHandle = editingHandleParams[paramKey] || false;
-
-        // SchemaProviderNode 특별 로직: description 파라미터는 숨김 (첫 번째 파라미터에서 함께 처리)
-        if (param.is_added && param.id.endsWith('_description') && !param.handle_id) {
-            return null; // description 파라미터는 렌더링하지 않음
-        }
-
-        // 연동된 description 파라미터 찾기 (첫 번째 파라미터인 경우)
-        const descriptionParam = param.is_added && param.handle_id
-            ? parameters?.find(p => p.id === `${param.id}_description`)
-            : null;
-
-        // 옵션 처리 - 일반 옵션과 API 옵션 모두 지원
-        const effectiveOptions = param.options || [];
-        const isLoadingOptions = false;
-        const apiSingleValue = null;
-
-        // shouldRenderAsInput 정의 (API 관련 로직 제거했으므로 false로 설정)
-        const shouldRenderAsInput = false;
-
-        return (
-            <div key={param.id} className={`${styles.param} param`}>
-                <span className={`${styles.paramKey} ${param.required ? styles.required : ''}`}>
-                    {param.description && param.description.trim() !== '' && (
-                        <div
-                            className={styles.infoIcon}
-                            onMouseEnter={() => setHoveredParam(param.id)}
-                            onMouseLeave={() => setHoveredParam(null)}
-                        >
-                            ?
-                            {hoveredParam === param.id && (
-                                <div className={styles.tooltip}>
-                                    {param.description}
-                                </div>
-                            )}
-                        </div>
-                    )}
-                    {isHandleParam ? (
-                        // handle_id가 true인 경우 클릭으로 편집 가능한 name
-                        isEditingHandle ? (
-                            <input
-                                type="text"
-                                value={editingHandleValues[paramKey] || ''}
-                                onChange={(e) => handleHandleParamChange(e, param)}
-                                onKeyDown={(e) => handleHandleParamKeyDown(e, param)}
-                                onBlur={() => handleHandleParamBlur(param)}
-                                onMouseDown={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onFocus={(e) => {
-                                    e.stopPropagation();
-                                    if (onClearSelection) {
-                                        onClearSelection();
-                                    }
-                                }}
-                                onDragStart={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                }}
-                                draggable={false}
-                                className={styles.nameInput}
-                                autoFocus
-                            />
-                        ) : (
-                            <span
-                                onClick={() => handleHandleParamClick(param)}
-                                className={styles.nodeName}
-                                style={{ cursor: isPreview ? 'default' : 'pointer' }}
-                            >
-                                {param.name && param.name.toString().trim() ? param.name : param.id}
-                            </span>
-                        )
-                    ) : (
-                        param.name
-                    )}
-                    {param.is_added && !isPreview && onParameterDelete && (
-                        <button
-                            className={styles.deleteParameterButton}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                handleDeleteParameter(param.id);
-                            }}
-                            type="button"
-                            title="Delete parameter"
-                        >
-                            <LuX />
-                        </button>
-                    )}
-                </span>
-                {isHandleParam ? (
-                    // handle_id가 true인 경우: 옵션이 있으면 select, 없으면 input
-                    <div className={styles.doubleInputWrapper || `${styles.paramInput} doubleInputWrapper`}>
-                        {effectiveOptions.length > 0 ? (
-                            <select
-                                value={param.value !== undefined && param.value !== null ? param.value.toString() : ''}
-                                onChange={(e) => {
-                                    devLog.log('=== Handle Param Select Change ===');
-                                    devLog.log('Parameter:', param.name, 'Previous value:', param.value, 'New value:', e.target.value);
-                                    devLog.log('Available options:', effectiveOptions);
-                                    handleParamValueChange(e, param.id);
-                                    devLog.log('=== Handle Param Select Change Complete ===');
-                                }}
-                                onMouseDown={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onFocus={(e) => {
-                                    e.stopPropagation();
-                                    if (onClearSelection) {
-                                        onClearSelection();
-                                    }
-                                }}
-                                onKeyDown={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onDragStart={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                }}
-                                draggable={false}
-                                className={`${styles.paramSelect} paramSelect`}
-                            >
-                                <option value="">-- Select --</option>
-                                {effectiveOptions.map((option, index) => (
-                                    <option key={index} value={option.value}>
-                                        {option.label || option.value}
-                                    </option>
-                                ))}
-                            </select>
-                        ) : (
-                            <input
-                                type="text"
-                                value={param.value !== undefined && param.value !== null ? param.value.toString() : ''}
-                                onChange={(e) => handleParamValueChange(e, param.id)}
-                                onMouseDown={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onFocus={(e) => {
-                                    e.stopPropagation();
-                                    if (onClearSelection) {
-                                        onClearSelection();
-                                    }
-                                }}
-                                onKeyDown={(e) => {
-                                    e.stopPropagation();
-                                }}
-                                onDragStart={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                }}
-                                draggable={false}
-                                className={`${styles.paramInput} paramInput`}
-                                placeholder="Value"
-                            />
-                        )}
-                        {descriptionParam && (
-                            descriptionParam.expandable ? (
-                                <div className={styles.expandableWrapper}>
-                                    <input
-                                        type="text"
-                                        value={descriptionParam.value.toString() || ''}
-                                        onChange={(e) => handleParamValueChange(e, descriptionParam.id)}
-                                        onMouseDown={(e) => {
-                                            devLog.log('expandable input onMouseDown');
-                                            e.stopPropagation();
-                                        }}
-                                        onClick={(e) => {
-                                            devLog.log('expandable input onClick');
-                                            e.stopPropagation();
-                                        }}
-                                        onFocus={(e) => {
-                                            devLog.log('expandable input onFocus');
-                                            e.stopPropagation();
-                                            if (onClearSelection) {
-                                                onClearSelection();
-                                            }
-                                        }}
-                                        onKeyDown={(e) => {
-                                            e.stopPropagation();
-                                        }}
-                                        onDragStart={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                        }}
-                                        draggable={false}
-                                        className={`${styles.paramInput} paramInput`}
-                                        placeholder="Description"
-                                        style={{ marginTop: '4px' }}
-                                    />
-                                    <button
-                                        className={styles.expandButton}
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            if (onOpenNodeModal) {
-                                                onOpenNodeModal(id, descriptionParam.id, descriptionParam.name, String(descriptionParam.value || ''));
-                                            }
-                                        }}
-                                        type="button"
-                                        title="Expand to edit"
-                                        style={{ marginTop: '4px' }}
-                                    >
-                                        ⧉
-                                    </button>
-                                </div>
-                            ) : (
-                                <input
-                                    type="text"
-                                    value={descriptionParam.value.toString() || ''}
-                                    onChange={(e) => handleParamValueChange(e, descriptionParam.id)}
-                                    onMouseDown={(e) => {
-                                        e.stopPropagation();
-                                    }}
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                    }}
-                                    onFocus={(e) => {
-                                        e.stopPropagation();
-                                        if (onClearSelection) {
-                                            onClearSelection();
-                                        }
-                                    }}
-                                    onKeyDown={(e) => {
-                                        e.stopPropagation();
-                                    }}
-                                    onDragStart={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                    }}
-                                    draggable={false}
-                                    className={`${styles.paramInput} paramInput`}
-                                    placeholder="Description"
-                                    style={{ marginTop: '4px' }}
-                                />
-                            )
-                        )}
-                    </div>
-                ) : shouldRenderAsInput ? (
-                    // API에서 단일 값을 로드한 경우 input으로 렌더링
-                    <input
-                        type="text"
-                        value={param.value !== undefined && param.value !== null ? param.value.toString() : (apiSingleValue || '')}
-                        onChange={(e) => handleParamValueChange(e, param.id)}
-                        onMouseDown={(e) => {
-                            devLog.log('api single value input onMouseDown');
-                            e.stopPropagation();
-                        }}
-                        onClick={(e) => {
-                            devLog.log('api single value input onClick');
-                            e.stopPropagation();
-                        }}
-                        onFocus={(e) => {
-                            devLog.log('api single value input onFocus');
-                            e.stopPropagation();
-                            // Clear node selection when editing parameter
-                            if (onClearSelection) {
-                                onClearSelection();
-                            }
-                        }}
-                        onKeyDown={(e) => {
-                            // Prevent keyboard event propagation
-                            e.stopPropagation();
-                        }}
-                        onDragStart={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                        }}
-                        draggable={false}
-                        className={`${styles.paramInput} paramInput`}
-                        placeholder={apiSingleValue ? `Default: ${apiSingleValue}` : ''}
-                    />
-                ) : effectiveOptions.length > 0 ? (
-                    <select
-                        value={param.value !== undefined && param.value !== null ? param.value.toString() : ''}
-                        onChange={(e) => {
-                            devLog.log('=== Select Parameter Change ===');
-                            devLog.log('Parameter:', param.name, 'Previous value:', param.value, 'New value:', e.target.value);
-                            devLog.log('Available options:', effectiveOptions);
-                            handleParamValueChange(e, param.id);
-                            devLog.log('=== Select Parameter Change Complete ===');
-                        }}
-                        onMouseDown={(e) => {
-                            devLog.log('select onMouseDown');
-                            e.stopPropagation();
-                        }}
-                        onClick={(e) => {
-                            devLog.log('select onClick');
-                            e.stopPropagation();
-                        }}
-                        onFocus={(e) => {
-                            devLog.log('select onFocus - Parameter:', param.name, 'Current value:', param.value);
-                            e.stopPropagation();
-                            // Clear node selection when editing parameter
-                            if (onClearSelection) {
-                                onClearSelection();
-                            }
-                        }}
-                        onBlur={(e) => {
-                            devLog.log('select onBlur - Parameter:', param.name, 'Final value:', e.target.value);
-                            e.stopPropagation();
-                        }}
-                        onKeyDown={(e) => {
-                            // Prevent keyboard event propagation
-                            e.stopPropagation();
-                        }}
-                        onDragStart={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                        }}
-                        draggable={false}
-                        className={`${styles.paramSelect} paramSelect`}
-                        disabled={isLoadingOptions}
-                    >
-                        {isLoadingOptions ? (
-                            <option value="">Loading...</option>
-                        ) : effectiveOptions.length === 0 ? (
-                            <option value="">-- No options available --</option>
-                        ) : (
-                            <>
-                                <option value="">-- Select --</option>
-                                {effectiveOptions.map((option, index) => (
-                                    <option key={index} value={option.value}>
-                                        {option.label || option.value}
-                                    </option>
-                                ))}
-                            </>
-                        )}
-                    </select>
-                ) : (param as any).expandable ? (
-                    <div className={styles.expandableWrapper}>
-                        <input
-                            type="text"
-                            value={param.value !== undefined && param.value !== null ? param.value.toString() : ''}
-                            onChange={(e) => handleParamValueChange(e, param.id)}
-                            onMouseDown={(e) => {
-                                devLog.log('expandable input onMouseDown');
-                                e.stopPropagation();
-                            }}
-                            onClick={(e) => {
-                                devLog.log('expandable input onClick');
-                                e.stopPropagation();
-                            }}
-                            onFocus={(e) => {
-                                devLog.log('expandable input onFocus');
-                                e.stopPropagation();
-                                if (onClearSelection) {
-                                    onClearSelection();
-                                }
-                            }}
-                            onKeyDown={(e) => {
-                                e.stopPropagation();
-                            }}
-                            onDragStart={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                            }}
-                            draggable={false}
-                            className={`${styles.paramInput} paramInput`}
-                            readOnly
-                            placeholder="Click expand button to edit..."
-                        />
-                        <button
-                            className={styles.expandButton}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                if (onOpenNodeModal) {
-                                    onOpenNodeModal(id, param.id, param.name, String(param.value || ''));
-                                }
-                            }}
-                            type="button"
-                            title="Expand to edit"
-                        >
-                            ⧉
-                        </button>
-                    </div>
-                ) : (
-                    <input
-                        type={param.type && numberList.includes(param.type) ? 'number' : 'text'}
-                        value={(param.value !== undefined && param.value !== null) ? param.type === 'STR' ? param.value.toString(): parseFloat(param.value.toString()): ''}
-                        onChange={(e) => handleParamValueChange(e, param.id)}
-                        onMouseDown={(e) => {
-                            devLog.log('input onMouseDown');
-                            e.stopPropagation();
-                        }}
-                        onClick={(e) => {
-                            devLog.log('input onClick');
-                            e.stopPropagation();
-                        }}
-                        onFocus={(e) => {
-                            devLog.log('input onFocus');
-                            e.stopPropagation();
-                            // Clear node selection when editing parameter
-                            if (onClearSelection) {
-                                onClearSelection();
-                            }
-                        }}
-                        onKeyDown={(e) => {
-                            // Prevent keyboard event propagation (backspace, delete, etc.)
-                            e.stopPropagation();
-                        }}
-                        onDragStart={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                        }}
-                        draggable={false}
-                        className={`${styles.paramInput} paramInput`}
-                        step={param.step}
-                        min={param.min}
-                        max={param.max}
-                    />
-                )}
-            </div>
-        );
-    };
-
+    // Event handlers
     const handleMouseDown = (e: React.MouseEvent): void => {
-        if (isPreview) return; // Disable drag in preview mode
+        if (isPreview) return;
+
+        // Handle predicted node click
+        if (isPredicted && onPredictedNodeClick) {
+            e.stopPropagation();
+            onPredictedNodeClick(data, position);
+            return;
+        }
+
         e.stopPropagation();
         onNodeMouseDown(e, id);
     };
 
-    const handleParamValueChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>, paramId: string): void => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        try {
-            // Value validation
-            const value = e.target.value;
-            if (value === undefined || value === null) {
-                devLog.warn('Invalid parameter value:', value);
-                return;
-            }
-
-            devLog.log('Calling onParameterChange...');
-            // Safe callback call
-            if (typeof onParameterChange === 'function') {
-                onParameterChange(id, paramId, value);
-                devLog.log('onParameterChange completed successfully');
-            } else {
-                devLog.error('onParameterChange is not a function');
-            }
-        } catch (error) {
-            devLog.error('Error in handleParamValueChange:', error);
+    const handleMouseEnter = (): void => {
+        if (isPredicted && onPredictedNodeHover) {
+            onPredictedNodeHover(id, true);
         }
-        devLog.log('=== End Parameter Change ===');
     };
 
-    const hasInputs = inputs && inputs.length > 0;
-    const hasOutputs = outputs && outputs.length > 0;
-    const hasIO = hasInputs || hasOutputs;
-    const hasParams = true;
-    const hasOnlyOutputs = hasOutputs && !hasInputs;
+    const handleMouseLeave = (): void => {
+        if (isPredicted && onPredictedNodeHover) {
+            onPredictedNodeHover(id, false);
+        }
+    };
 
-    const displayName = nodeName.length > 25 ? nodeName.substring(0, 25) + '...' : nodeName;
+    const handleToggleAdvanced = (e: React.MouseEvent): void => {
+        e.stopPropagation();
+        setShowAdvanced(prev => !prev);
+    };
+
+    const handleSynchronizeSchema = (portId: string): void => {
+        if (!onSynchronizeSchema) return;
+        onSynchronizeSchema(id, portId);
+    };
+
+    // Utility calculations
+    const { hasIO } = hasInputsAndOutputs(inputs, outputs);
+    const hasParams = hasParameters(parameters);
+
+    // Node container classes and styles
+    const nodeClasses = getNodeContainerClasses(isSelected, isPreview, isPredicted, styles.node);
+    const nodeStyles = getNodeContainerStyles(position, isPredicted, predictedOpacity);
+
 
     return (
-        <>
-            <div
-                className={`${styles.node} ${isSelected ? styles.selected : ''} ${isPreview ? 'preview' : ''}`}
-                style={{ transform: `translate(${position.x}px, ${position.y}px)` }}
-                onMouseDown={handleMouseDown}
-            >
-                <div className={styles.header}>
-                    {isEditingName ? (
-                        <input
-                            type="text"
-                            value={editingName}
-                            onChange={handleNameChange}
-                            onKeyDown={handleNameKeyDown}
-                            onBlur={handleNameBlur}
-                            onMouseDown={(e) => {
-                                e.stopPropagation();
-                            }}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                            }}
-                            onFocus={(e) => {
-                                e.stopPropagation();
-                            }}
-                            onDragStart={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                            }}
-                            draggable={false}
-                            className={styles.nameInput}
-                            autoFocus
+        <div
+            className={nodeClasses}
+            style={nodeStyles}
+            onMouseDown={handleMouseDown}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+        >
+            {/* Header Section */}
+            <NodeHeader
+                nodeName={nodeName}
+                functionId={functionId}
+                isEditingName={nodeEditingHook.isEditingName}
+                editingName={nodeEditingHook.editingName}
+                isPreview={isPreview}
+                onNameDoubleClick={(e) => nodeEditingHook.handleNameDoubleClick(e, nodeName, isPreview)}
+                onNameChange={nodeEditingHook.handleNameChange}
+                onNameKeyDown={nodeEditingHook.handleNameKeyDown}
+                onNameBlur={() => nodeEditingHook.handleNameBlur(id, nodeName, onNodeNameChange)}
+                onClearSelection={onClearSelection}
+            />
+
+            {/* Body Section */}
+            <div className={styles.body}>
+                {/* Input/Output Ports */}
+                {hasIO && (
+                    <NodePorts
+                        nodeId={id}
+                        inputs={inputs}
+                        outputs={outputs}
+                        isPreview={isPreview}
+                        isPredicted={isPredicted}
+                        isSelected={isSelected}
+                        onPortMouseDown={onPortMouseDown}
+                        onPortMouseUp={onPortMouseUp}
+                        registerPortRef={registerPortRef}
+                        snappedPortKey={snappedPortKey}
+                        isSnapTargetInvalid={isSnapTargetInvalid}
+                        currentNodes={currentNodes}
+                        currentEdges={currentEdges}
+                        onSynchronizeSchema={handleSynchronizeSchema}
+                    />
+                )}
+
+                {/* Parameters */}
+                {hasParams && !isPredicted && (
+                    <>
+                        {hasIO && <div className={styles.divider}></div>}
+                        <SchemaProviderNodeParameters
+                            nodeId={id}
+                            nodeDataId={data.id}
+                            parameters={parameters}
+                            isPreview={isPreview}
+                            isPredicted={isPredicted}
+                            onParameterChange={onParameterChange}
+                            onParameterNameChange={onParameterNameChange}
+                            onParameterAdd={onParameterAdd}
+                            onParameterDelete={onParameterDelete}
+                            onClearSelection={onClearSelection}
+                            onOpenNodeModal={onOpenNodeModal}
+                            showAdvanced={showAdvanced}
+                            onToggleAdvanced={handleToggleAdvanced}
                         />
-                    ) : (
-                        <span onDoubleClick={handleNameDoubleClick} className={styles.nodeName}>
-                            {displayName}
-                        </span>
-                    )}
-                    {functionId && <span className={styles.functionId}>({functionId})</span>}
-                </div>
-                <div className={styles.body}>
-                    {hasIO && (
-                        <div className={styles.ioContainer}>
-                            {hasInputs && (
-                                <div className={styles.column}>
-                                    <div className={styles.sectionHeader}>INPUT</div>
-                                    {inputs.map(portData => {
-                                        const portKey = `${id}__PORTKEYDELIM__${portData.id}__PORTKEYDELIM__input`;
-                                        const isSnapping = snappedPortKey === portKey;
-
-                                        const portClasses = [
-                                            styles.port,
-                                            styles.inputPort,
-                                            portData.multi ? styles.multi : '',
-                                            styles[`type-${portData.type}`],
-                                            isSnapping ? styles.snapping : '',
-                                            isSnapping && isSnapTargetInvalid ? styles['invalid-snap'] : ''
-                                        ].filter(Boolean).join(' ');
-
-                                        return (
-                                            <div key={portData.id} className={styles.portRow}>
-                                                <div
-                                                    ref={(el) => registerPortRef && registerPortRef(id, portData.id, 'input', el)}
-                                                    className={portClasses}
-                                                    onMouseDown={isPreview ? undefined : (e) => {
-                                                        e.stopPropagation();
-                                                        onPortMouseDown({
-                                                            nodeId: id,
-                                                            portId: portData.id,
-                                                            portType: 'input',
-                                                            isMulti: portData.multi,
-                                                            type: portData.type
-                                                        });
-                                                    }}
-                                                    onMouseUp={isPreview ? undefined : (e) => {
-                                                        e.stopPropagation();
-                                                        onPortMouseUp({
-                                                            nodeId: id,
-                                                            portId: portData.id,
-                                                            portType: 'input',
-                                                            type: portData.type
-                                                        });
-                                                    }}
-                                                >
-                                                    {portData.type}
-                                                </div>
-                                                <span className={`${styles.portLabel} ${portData.required ? styles.required : ''}`}>
-                                                    {portData.name}
-                                                </span>
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            )}
-                            {hasOutputs && (
-                                <div className={`${styles.column} ${styles.outputColumn} ${hasOnlyOutputs ? styles.fullWidth : ''}`}>
-                                    <div className={styles.sectionHeader}>OUTPUT</div>
-                                    {outputs.map(portData => {
-                                        const portClasses = [
-                                            styles.port,
-                                            styles.outputPort,
-                                            portData.multi ? styles.multi : '',
-                                            styles[`type-${portData.type}`]
-                                        ].filter(Boolean).join(' ');
-
-                                        return (
-                                            <div key={portData.id} className={`${styles.portRow} ${styles.outputRow}`}>
-                                                <span className={styles.portLabel}>{portData.name}</span>
-                                                <div
-                                                    ref={(el) => registerPortRef && registerPortRef(id, portData.id, 'output', el)}
-                                                    className={portClasses}
-                                                    onMouseDown={isPreview ? undefined : (e) => {
-                                                        e.stopPropagation();
-                                                        onPortMouseDown({
-                                                            nodeId: id,
-                                                            portId: portData.id,
-                                                            portType: 'output',
-                                                            isMulti: portData.multi,
-                                                            type: portData.type
-                                                        });
-                                                    }}
-                                                    onMouseUp={isPreview ? undefined : (e) => {
-                                                        e.stopPropagation();
-                                                        onPortMouseUp({
-                                                            nodeId: id,
-                                                            portId: portData.id,
-                                                            portType: 'output',
-                                                            type: portData.type
-                                                        });
-                                                    }}
-                                                >
-                                                    {portData.type}
-                                                </div>
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            )}
-                        </div>
-                    )}
-                    {hasParams && (
-                        <>
-                            {hasIO && <div className={styles.divider}></div>}
-                            <div className={styles.paramSection}>
-                                <div className={styles.sectionHeader}>
-                                    <span>PARAMETER</span>
-                                    {!isPreview && onParameterAdd && (
-                                        <button
-                                            className={styles.addParameterButton}
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                handleAddCustomParameter();
-                                            }}
-                                            type="button"
-                                            title="Add custom parameter"
-                                        >
-                                            <LuPlus />
-                                        </button>
-                                    )}
-                                </div>
-                                {basicParameters.map(param => renderParameter(param))}
-                                {hasAdvancedParams && (
-                                    <div className={styles.advancedParams}>
-                                        {showAdvanced && advancedParameters.map(param => renderParameter(param))}
-                                    </div>
-                                )}
-                            </div>
-                        </>
-                    )}
-                </div>
+                    </>
+                )}
             </div>
-        </>
+        </div>
     );
 };
 


### PR DESCRIPTION
### 설명
- SchemaProviderNode의 복잡한 파라미터 처리 로직을 개선하고, 파라미터 컴포넌트를 분리하여 재사용성과 유지보수성을 높이기 위해 리팩토링을 진행했습니다.
- 기존에 SchemaProviderNode 내에 직접 구현되어 있던 파라미터, 이름 편집, 추가/삭제, 설명 처리 로직을 별도의 컴포넌트와 커스텀 훅으로 분리하였고, 이벤트 핸들링과 UI 렌더링을 모듈화했습니다.
- 이를 통해 코드 중복과 복잡도를 줄이고, 특별 파라미터(**kwargs 형태)의 추가 및 삭제, 편집 기능을 명확하게 분리 처리할 수 있게 되었습니다.

### 주요 변경 사항
- `SchemaProviderParameter` 컴포넌트 추가: 파라미터와 설명 파라미터를 함께 관리하는 UI 컴포넌트로 분리하여, 선택형 입력(select)과 텍스트 입력을 상황에 맞게 렌더링하도록 구현.
- `SchemaProviderNodeParameters` 컴포넌트 추가: SchemaProviderNode에서 사용하는 파라미터들을 기본/고급으로 분리하고, 파라미터 추가/삭제/이름 변경 로직을 전담하도록 분리.
- `SchemaProviderNode` 컴포넌트 리팩토링
  - 내부 상태 관리를 커스텀 훅(`useNodeEditing`)으로 대체.
  - 직접 구현하던 파라미터 렌더링 로직을 `SchemaProviderNodeParameters` 컴포넌트로 위임.
  - 노드 이름 편집, 마우스 이벤트 핸들링, 포트 렌더링 등 UI와 행위 분리.
  - 예측 모드(`isPredicted`) 및 관련 이벤트 처리 추가.
- 파라미터 편집 시 연관된 설명 파라미터 이름도 함께 변경 및 삭제 되도록 구현하여 무결성 유지.
- 기존 불필요한 API 관련 옵션 처리 및 디버깅 코드 제거, 코드 가독성 및 안정성 개선.
- 스타일 적용 및 이벤트 전파 차단 등 UI/UX 세부 조정.