### PR TITLE
[리팩토링] Node 컴포넌트 및 SchemaProviderNode의 스타일 적용 방식 개선

### DIFF
--- a/src/app/canvas/components/Node/index.tsx
+++ b/src/app/canvas/components/Node/index.tsx
@@ -91,7 +91,7 @@ const Node: React.FC<NodeProps> = ({
     const displayName = getDisplayNodeName(nodeName);
 
     // Node container classes and styles
-    const nodeClasses = getNodeContainerClasses(isSelected, isPreview, isPredicted, styles.node);
+    const nodeClasses = getNodeContainerClasses(isSelected, isPreview, isPredicted, styles);
     const nodeStyles = getNodeContainerStyles(position, isPredicted, predictedOpacity);
 
     return (

--- a/src/app/canvas/components/Node/utils/nodeUtils.ts
+++ b/src/app/canvas/components/Node/utils/nodeUtils.ts
@@ -120,13 +120,13 @@ export const getNodeContainerClasses = (
     isSelected: boolean,
     isPreview: boolean,
     isPredicted: boolean,
-    baseClass: string = 'node'
+    styles: any
 ): string => {
     const classes = [
-        baseClass,
-        isSelected ? 'selected' : '',
-        isPreview ? 'preview' : '',
-        isPredicted ? 'predicted' : ''
+        styles.node,
+        isSelected ? styles.selected : '',
+        isPreview ? styles.preview : '',
+        isPredicted ? styles.predicted : ''
     ].filter(Boolean);
     
     return classes.join(' ');

--- a/src/app/canvas/components/SpecialNode/SchemaProviderNode.tsx
+++ b/src/app/canvas/components/SpecialNode/SchemaProviderNode.tsx
@@ -87,7 +87,7 @@ const SchemaProviderNode: React.FC<NodeProps> = ({
     const { hasIO } = hasInputsAndOutputs(inputs, outputs);
 
     // Node container classes and styles
-    const nodeClasses = getNodeContainerClasses(isSelected, isPreview, isPredicted, styles.node);
+    const nodeClasses = getNodeContainerClasses(isSelected, isPreview, isPredicted, styles);
     const nodeStyles = getNodeContainerStyles(position, isPredicted, predictedOpacity);
 
 


### PR DESCRIPTION
### 설명
- Node 관련 컴포넌트에서 CSS 클래스 이름을 전달하는 방식을 개선하여 스타일 관리 일관성을 높이기 위해 리팩토링을 진행했습니다.
- 기존에는 클래스 이름들을 문자열로 직접 전달했으나, 이를 styles 객체를 사용하도록 변경하여 스타일링 유지보수 및 확장성을 개선했습니다.

### 주요 변경 사항
- `getNodeContainerClasses` 함수의 인자를 문자열 기반 `baseClass`에서 스타일 객체인 `styles`로 변경함.
- `Node` 컴포넌트 내에서 `getNodeContainerClasses` 호출 시 기존의 단일 클래스명 대신 styles 객체를 전달하도록 수정.
- `SchemaProviderNode` 컴포넌트에서도 동일하게 스타일 객체를 전달하도록 변경하여 코드 일관성 확보.
- 이를 통해 선택(selected), 미리보기(preview), 예측(predicted) 상태에 따른 클래스 적용을 styles 객체 기반으로 처리하도록 개선.