### PR TITLE
[기능] 배포 상태 조회 시 사용자 ID 지원 및 배포 상태 토글 기능 추가

### DIFF
--- a/src/app/api/workflow/deploy.ts
+++ b/src/app/api/workflow/deploy.ts
@@ -37,14 +37,23 @@ export interface DeployKeyResponse {
 export const getDeployStatus = async (workflowName: string, user_id?: number | string): Promise<DeployStatus> => {
     try {
         devLog.log(`Getting deploy status for workflow: ${workflowName}`);
+        devLog.log(`User ID: ${user_id}`);
 
-        const response = await apiClient(`${API_BASE_URL}/api/workflow/deploy/status/${encodeURIComponent(workflowName)}`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ user_id: user_id || "" })
-        });
+        const response = user_id 
+            ? await fetch(`${API_BASE_URL}/api/workflow/deploy/status/${encodeURIComponent(workflowName)}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ user_id })
+            })
+            : await apiClient(`${API_BASE_URL}/api/workflow/deploy/status/${encodeURIComponent(workflowName)}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ user_id: "" })
+            });
 
         if (!response.ok) {
             const errorData = await response.json();

--- a/src/app/chat/assets/ChatInterface.module.scss
+++ b/src/app/chat/assets/ChatInterface.module.scss
@@ -1,4 +1,5 @@
 @use '@/app/_common/_variables.scss' as *;
+@use "sass:color";
 
 .container {
     width: 100%;
@@ -1051,6 +1052,47 @@
       margin-bottom: 0.5rem;
       font-size: 0.9rem;
       font-weight: 600;
+    }
+}
+.deployInfo {
+    display: flex;
+    align-items: center;           /* <- 추가: 요소들을 수직 중앙으로 정렬 */
+    justify-content: space-between;  /* <- 추가: 요소들을 양쪽 끝으로 분배 */
+    margin-bottom: 1rem;
+    p {
+        margin: 0;
+    }
+}
+.toggleButton {
+    width: 15%;
+    border: 2px solid $gray-300;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    background: $white;
+    color: $gray-700;
+    margin-left: auto;
+
+    &:hover:not(:disabled) {
+        border-color: $primary-blue;
+        background: $gray-50;
+    }
+
+    &.active {
+        border-color: $primary-blue;
+        background: $primary-blue;
+        color: $white;
+
+        &:hover:not(:disabled) {
+            background: color.adjust($primary-blue, $lightness: -7%);
+        }
+    }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
     }
 }
 .payloadTextarea {

--- a/src/app/chat/components/DeploymentModal.tsx
+++ b/src/app/chat/components/DeploymentModal.tsx
@@ -9,6 +9,7 @@ import { showCopySuccessToastKo, showCopyErrorToastKo } from '@/app/_common/util
 import { Workflow } from './types';
 import { getAuthCookie } from '@/app/_common/utils/cookieUtils';
 import { createEncryptedUrlParams } from '@/app/_common/utils/urlEncryption';
+import { getDeployStatus, toggleDeployStatus } from '@/app/api/workflow/deploy';
 
 interface DeploymentModalProps {
     isOpen: boolean;
@@ -136,12 +137,28 @@ export const DeploymentModal: React.FC<DeploymentModalProps> = ({ isOpen, onClos
     const closeButtonRef = useRef<HTMLButtonElement>(null);
     const currentUser_id = getAuthCookie('user_id') as string;
     const user_id = workflow.user_id ? workflow.user_id.toString() : currentUser_id;
+    const [toggleDeploy, setToggleDeploy] = useState<boolean>(false);
+    const [loading, setLoading] = useState(false);
 
     useEffect(() => {
         if (typeof window !== 'undefined') {
             setBaseUrl(window.location.origin);
         }
     }, []);
+    useEffect(() => {
+        const fetchDeployStatus = async () => {
+            if (workflow) {
+                try {
+                    const deployed = await getDeployStatus(workflow.name);
+                    setToggleDeploy(deployed.is_deployed);
+                } catch (err) {
+                    console.error('Failed to fetch deploy status:', err);
+                }
+            }
+        };
+
+        fetchDeployStatus();
+    }, [workflow]);
 
     useEffect(() => {
         if (isOpen) {
@@ -370,7 +387,20 @@ ${formatOutputSchemaForCode(outputSchema, 1)}
                 <div className={styles.deploymentModalContent}>
                     {activeTab === 'website' && (
                         <div className={styles.tabPanel}>
-                            <p>아래 링크를 통해 독립된 웹페이지에서 채팅을 사용할 수 있습니다.</p>
+                            <div className={styles.deployInfo}>
+                                <p>아래 링크를 통해 독립된 웹페이지에서 채팅을 사용할 수 있습니다.</p>
+                                <button
+                                    type="button"
+                                    className={`${styles.toggleButton} ${toggleDeploy ? styles.active : ''}`}
+                                    onClick={async () => {
+                                        setToggleDeploy(!toggleDeploy);
+                                        await toggleDeployStatus(workflow.name, !toggleDeploy);
+                                    }}
+                                    disabled={loading}
+                                >
+                                    {toggleDeploy ? '배포 중' : '비공개'}
+                                </button>
+                            </div>
                             <div className={styles.webPageUrl}>
                                 <a href={baseUrl ? webPageUrl : '#'} target="_blank" rel="noopener noreferrer">
                                     {baseUrl ? webPageUrl : 'URL 생성 중...'}

--- a/src/app/chat/components/DeploymentModal.tsx
+++ b/src/app/chat/components/DeploymentModal.tsx
@@ -147,9 +147,9 @@ export const DeploymentModal: React.FC<DeploymentModalProps> = ({ isOpen, onClos
     }, []);
     useEffect(() => {
         const fetchDeployStatus = async () => {
-            if (workflow) {
+            if (workflow && user_id) {
                 try {
-                    const deployed = await getDeployStatus(workflow.name);
+                    const deployed = await getDeployStatus(workflow.name, user_id);
                     setToggleDeploy(deployed.is_deployed);
                 } catch (err) {
                     console.error('Failed to fetch deploy status:', err);
@@ -158,7 +158,7 @@ export const DeploymentModal: React.FC<DeploymentModalProps> = ({ isOpen, onClos
         };
 
         fetchDeployStatus();
-    }, [workflow]);
+    }, [workflow, user_id]);
 
     useEffect(() => {
         if (isOpen) {

--- a/src/app/chat/components/SoundInput/SoundInputModal.tsx
+++ b/src/app/chat/components/SoundInput/SoundInputModal.tsx
@@ -355,6 +355,8 @@ const SoundInput: React.FC<SoundInputProps> = ({
 
                 {audioUrl && state === "finished" && (
                     <div className={styles.playback}>
+                        
+                        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
                         <audio src={audioUrl} controls className={styles.audioPlayer} />
                         <div className={styles.actions}>
                             <button

--- a/src/app/chatbot/[chatId]/page.tsx
+++ b/src/app/chatbot/[chatId]/page.tsx
@@ -91,15 +91,6 @@ const StandaloneChatPage = () => {
                         return;
                     }
                 } else {
-                    // 배포 상태 확인 메시지 처리
-                    if (decryptedParams.message) {
-                        setError(decryptedParams.message === 'This workflow is not deployed.' 
-                            ? '이 워크플로우는 배포되지 않았습니다.' 
-                            : decryptedParams.message);
-                        setLoading(false);
-                        return;
-                    }
-                    
                     setUserId(decryptedParams.userId);
                     setWorkflowName(decryptedParams.workflowName);
                 }
@@ -143,7 +134,7 @@ const StandaloneChatPage = () => {
         };
 
         handleDecryption();
-    }, [encryptedParams, workflowNameFromUrl, userId, workflowName]);
+    }, [encryptedParams, workflowNameFromUrl]);
 
     if (loading) {
         return (


### PR DESCRIPTION
### 설명
- 기존 배포 상태 조회 기능에 사용자별 상태 확인을 위한 user_id 지원을 추가했습니다.
- 배포 모달(DeploymentModal) 내에서 현재 배포 상태를 확인하고, 버튼 클릭으로 배포 상태를 토글할 수 있도록 하여 UI/UX를 개선했습니다.
- 이를 통해 워크플로우 배포 관리가 보다 직관적이고 사용자 맞춤형으로 변경됩니다.

### 주요 변경 사항
- `getDeployStatus` API 함수에 선택적 `user_id` 파라미터 추가, 사용자 단위 배포 상태 조회 지원
- `DeploymentModal` 컴포넌트에 배포 상태를 표시하는 토글 버튼 추가
  - 초기 렌더링 시 사용자 배포 상태를 API로부터 조회하여 버튼에 상태 반영
  - 버튼 클릭 시 `toggleDeployStatus` API를 호출해 실시간으로 배포 상태 변경 가능
- SCSS에 토글 버튼과 배포 정보 영역 스타일 추가하여 UI 개선
- 독립 웹페이지 링크 영역 우측에 배포 상태 토글 버튼 배치
- `chatbot/[chatId]/page.tsx`에서 불필요한 배포 상태 관련 에러 처리 주석 및 의존성 정리