### PR TITLE
fix: workflow sharing

### DIFF
--- a/src/app/_common/api/workflow/workflowAPI.js
+++ b/src/app/_common/api/workflow/workflowAPI.js
@@ -9,15 +9,25 @@ import { apiClient } from '@/app/_common/api/helper/apiClient';
  * @returns {Promise<Object>} API 응답 객체를 포함하는 프로미스
  * @throws {Error} API 요청이 실패하면 에러를 발생시킵니다.
  */
-export const saveWorkflow = async (workflowName, workflowContent) => {
+export const saveWorkflow = async (workflowName, workflowContent, userId = null) => {
     try {
         devLog.log('SaveWorkflow called with:');
         devLog.log('- workflowName (name):', workflowName);
         devLog.log('- workflowContent.id:', workflowContent.id);
+        devLog.log('- userId:', userId);
         devLog.log(
             '- Full workflowContent keys:',
             Object.keys(workflowContent),
         );
+
+        const requestBody = {
+            workflow_name: workflowName,
+            content: workflowContent,
+        };
+
+        if (userId !== null && (typeof userId === 'number' || (typeof userId === 'string' && /^\d+$/.test(userId)))) {
+            requestBody.user_id = userId;
+        }
 
         // apiClient가 자동으로 Authorization header와 X-User-ID header를 추가합니다
         const response = await apiClient(`${API_BASE_URL}/api/workflow/save`, {
@@ -25,10 +35,7 @@ export const saveWorkflow = async (workflowName, workflowContent) => {
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-                workflow_name: workflowName,
-                content: workflowContent,
-            }),
+            body: JSON.stringify(requestBody),
         });
 
         const result = await response.json();

--- a/src/app/canvas/assets/Canvas.module.scss
+++ b/src/app/canvas/assets/Canvas.module.scss
@@ -17,8 +17,8 @@
 
     background-color: $canvas-grid-background;
     background-image:
-        linear-gradient($canvas-grid-minor 3px, transparent 3px),
-        linear-gradient(90deg, $canvas-grid-minor 3px, transparent 3px),
+        linear-gradient($canvas-grid-minor 1px, transparent 1px),
+        linear-gradient(90deg, $canvas-grid-minor 1px, transparent 1px),
         linear-gradient($canvas-grid-major 3px, transparent 3px),
         linear-gradient(90deg, $canvas-grid-major 3px, transparent 3px);
 

--- a/src/app/canvas/assets/Header.module.scss
+++ b/src/app/canvas/assets/Header.module.scss
@@ -121,6 +121,27 @@
     }
 }
 
+.sharedIndicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+    color: #6c757d;
+    padding: 4px;
+    border-radius: 4px;
+    min-width: 24px;
+    min-height: 24px;
+    flex-shrink: 0;
+    cursor: help;
+    transition: all 0.2s ease;
+
+    &:hover {
+        background-color: #e9ecef;
+        color: #495057;
+        transform: scale(1.1);
+    }
+}
+
 .saveButton {
     color: #28a745;
 

--- a/src/app/canvas/components/Canvas/hooks/useKeyboardHandlers.ts
+++ b/src/app/canvas/components/Canvas/hooks/useKeyboardHandlers.ts
@@ -28,6 +28,11 @@ interface UseKeyboardHandlersReturn {
     handleKeyDown: (e: KeyboardEvent) => void;
 }
 
+const isCtrlOrCmdPressed = (e: KeyboardEvent): boolean => {
+    const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+    return isMac ? e.metaKey : e.ctrlKey;
+};
+
 export const useKeyboardHandlers = ({
     selectedNodeId,
     selectedEdgeId,
@@ -50,7 +55,7 @@ export const useKeyboardHandlers = ({
             return;
         }
 
-        const isCtrlOrCmd = e.ctrlKey || e.metaKey;
+        const isCtrlOrCmd = isCtrlOrCmdPressed(e);
 
         if (isCtrlOrCmd && e.key === 'c') {
             e.preventDefault();

--- a/src/app/canvas/components/Header.tsx
+++ b/src/app/canvas/components/Header.tsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect, useRef, KeyboardEvent, ChangeEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from '@/app/canvas/assets/Header.module.scss';
-import { LuPanelRightOpen, LuSave, LuCheck, LuX, LuPencil, LuFileText, LuArrowLeft, LuHistory } from "react-icons/lu";
+import { LuPanelRightOpen, LuSave, LuCheck, LuX, LuPencil, LuFileText, LuArrowLeft, LuHistory, LuUsers } from "react-icons/lu";
 import { getWorkflowName, saveWorkflowName } from '@/app/_common/utils/workflowStorage';
 import { FiUpload } from 'react-icons/fi';
 import { BiCodeAlt } from "react-icons/bi";
 import { showHistoryClearWarningKo } from '@/app/_common/utils/toastUtilsKo';
 
-// Type definitions
 interface HeaderProps {
     onMenuClick: () => void;
     onSave: () => void;
@@ -24,6 +23,7 @@ interface HeaderProps {
     onHistoryClick?: () => void;
     historyCount?: number;
     isHistoryPanelOpen?: boolean;
+    isOwner?: boolean;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -39,7 +39,8 @@ const Header: React.FC<HeaderProps> = ({
     isLoading,
     onHistoryClick,
     historyCount = 0,
-    isHistoryPanelOpen = false
+    isHistoryPanelOpen = false,
+    isOwner = true
 }) => {
     const [workflowName, setWorkflowName] = useState<string>('Workflow');
     const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -165,13 +166,23 @@ const Header: React.FC<HeaderProps> = ({
                     ) : (
                         <div className={styles.displayMode}>
                             <span className={styles.workflowName}>{workflowName}</span>
-                            <button
-                                onClick={handleEditClick}
-                                className={styles.editButton}
-                                title="Edit workflow name"
-                            >
-                                <LuPencil />
-                            </button>
+                            {!isOwner && (
+                                <span
+                                    className={styles.sharedIndicator}
+                                    title="공유받은 워크플로우입니다. 이름을 수정할 수 없습니다."
+                                >
+                                    <LuUsers />
+                                </span>
+                            )}
+                            {isOwner && (
+                                <button
+                                    onClick={handleEditClick}
+                                    className={styles.editButton}
+                                    title="Edit workflow name"
+                                >
+                                    <LuPencil />
+                                </button>
+                            )}
                         </div>
                     )}
                 </div>

--- a/src/app/main/workflowSection/assets/CompletedWorkflows.module.scss
+++ b/src/app/main/workflowSection/assets/CompletedWorkflows.module.scss
@@ -382,6 +382,13 @@
         }
     }
 
+    &.disabled {
+        cursor: not-allowed;
+        opacity: 0.45;
+        pointer-events: none;
+        background-color: $bootstrap-red;
+    }
+
     svg {
         width: 1rem;
         height: 1rem;

--- a/src/app/main/workflowSection/assets/CompletedWorkflows.module.scss
+++ b/src/app/main/workflowSection/assets/CompletedWorkflows.module.scss
@@ -384,9 +384,8 @@
 
     &.disabled {
         cursor: not-allowed;
-        opacity: 0.45;
+        opacity: 0.35;
         pointer-events: none;
-        background-color: $bootstrap-red;
     }
 
     svg {

--- a/src/app/main/workflowSection/components/CompletedWorkflows.tsx
+++ b/src/app/main/workflowSection/components/CompletedWorkflows.tsx
@@ -165,7 +165,7 @@ const CompletedWorkflows: React.FC = () => {
 
     const handleEdit = (workflow: Workflow) => {
         router.push(
-            `/canvas?load=${encodeURIComponent(workflow.name)}`,
+            `/canvas?load=${encodeURIComponent(workflow.name)}&user_id=${workflow.user_id}`,
         );
     };
 
@@ -454,6 +454,16 @@ const CompletedWorkflows: React.FC = () => {
                                             <>
                                                 <button
                                                     className={styles.actionButton}
+                                                    title="편집"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        handleEdit(workflow);
+                                                    }}
+                                                >
+                                                    <FiEdit />
+                                                </button>
+                                                <button
+                                                    className={styles.actionButton}
                                                     title="복사"
                                                     onClick={(e) => {
                                                         e.stopPropagation();
@@ -462,9 +472,6 @@ const CompletedWorkflows: React.FC = () => {
                                                 >
                                                     <FiCopy />
                                                 </button>
-                                                <div className={styles.sharedMessage}>
-                                                    공유받은 워크플로우는 편집이 불가능합니다.
-                                                </div>
                                             </>
                                         )}
                                     </>

--- a/src/app/main/workflowSection/components/CompletedWorkflows.tsx
+++ b/src/app/main/workflowSection/components/CompletedWorkflows.tsx
@@ -452,13 +452,25 @@ const CompletedWorkflows: React.FC = () => {
                                             </>
                                         ) : (
                                             <>
+                                                {/* 다른 사용자의 워크플로우 - 권한에 따라 편집 버튼 제어 */}
                                                 <button
-                                                    className={styles.actionButton}
-                                                    title="편집"
+                                                    className={`${styles.actionButton} ${
+                                                        workflow.share_permissions !== 'read_write'
+                                                            ? styles.disabled
+                                                            : ''
+                                                    }`}
+                                                    title={
+                                                        workflow.share_permissions !== 'read_write'
+                                                            ? "읽기 전용으로 공유되었습니다"
+                                                            : "편집"
+                                                    }
                                                     onClick={(e) => {
                                                         e.stopPropagation();
-                                                        handleEdit(workflow);
+                                                        if (workflow.share_permissions === 'read_write') {
+                                                            handleEdit(workflow);
+                                                        }
                                                     }}
+                                                    disabled={workflow.share_permissions !== 'read_write'}
                                                 >
                                                     <FiEdit />
                                                 </button>

--- a/src/app/main/workflowSection/components/workflows/WorkflowEditModal.tsx
+++ b/src/app/main/workflowSection/components/workflows/WorkflowEditModal.tsx
@@ -24,6 +24,7 @@ const WorkflowEditModal: React.FC<WorkflowEditModalProps> = ({
     const [isShared, setIsShared] = useState<boolean>(false);
     const [toggleDeploy, setToggleDeploy] = useState<boolean>(false);
     const [shareGroup, setShareGroup] = useState<string>('');
+    const [sharePermissions, setSharePermissions] = useState<string>('read');
     const [availableGroups, setAvailableGroups] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -33,6 +34,7 @@ const WorkflowEditModal: React.FC<WorkflowEditModalProps> = ({
         if (workflow) {
             setIsShared(workflow.is_shared === true);
             setShareGroup(workflow.share_group || '');
+            setSharePermissions(workflow.share_permissions || 'read');
 
             const workflowDetail = workflow as any;
             if (workflowDetail.inquire_deploy) {
@@ -74,6 +76,7 @@ const WorkflowEditModal: React.FC<WorkflowEditModalProps> = ({
             const updateDict = {
                 is_shared: isShared,
                 share_group: isShared ? shareGroup || null : null,
+                share_permissions: isShared ? sharePermissions : null,
                 enable_deploy: toggleDeploy  // 백엔드에서 관리자 권한에 따라 처리
             };
 
@@ -83,6 +86,7 @@ const WorkflowEditModal: React.FC<WorkflowEditModalProps> = ({
                 ...workflow,
                 is_shared: isShared,
                 share_group: isShared ? shareGroup || null : null,
+                share_permissions: isShared ? sharePermissions : null,
             };
 
             // 배포 상태: toggleDeploy가 true이면 'pending' (일반 사용자) 또는 true (관리자)
@@ -177,6 +181,23 @@ const WorkflowEditModal: React.FC<WorkflowEditModalProps> = ({
                                 ? "공유 그룹을 지정하지 않으면 공유되지 않습니다."
                                 : "그룹에 소속되어야 특정 그룹과 공유할 수 있습니다."
                             }
+                        </small>
+                    </div>
+                )}
+
+                {isShared && (
+                    <div className={styles.formGroup}>
+                        <label>권한</label>
+                        <select
+                            value={sharePermissions}
+                            onChange={(e) => setSharePermissions(e.target.value)}
+                            disabled={loading}
+                        >
+                            <option value="read">Read Only</option>
+                            <option value="read_write">Read and Write</option>
+                        </select>
+                        <small>
+                            공유된 워크플로우에 대한 접근 권한을 설정합니다.
                         </small>
                     </div>
                 )}


### PR DESCRIPTION
This pull request introduces enhancements to workflow sharing and editing permissions, improves the user interface for shared workflows, and refines keyboard handling and workflow saving logic. The main focus is on enabling granular sharing permissions (read-only vs. read-write), visually indicating workflow ownership, and ensuring that only authorized users can edit shared workflows. Additional improvements include UI tweaks for grid appearance and keyboard shortcut handling.

**Workflow sharing and permissions:**

* Added a `share_permissions` field (with options like "read" and "read_write") to workflows, allowing owners to specify whether shared users can edit or only view the workflow. The sharing modal now allows setting these permissions, and this information is saved and loaded with the workflow. [[1]](diffhunk://#diff-5f4b8cff0691aab1dd8fdc2d8c495f1468b565ae93ebd4b0ca766b326dbd074eR27) [[2]](diffhunk://#diff-5f4b8cff0691aab1dd8fdc2d8c495f1468b565ae93ebd4b0ca766b326dbd074eR37) [[3]](diffhunk://#diff-5f4b8cff0691aab1dd8fdc2d8c495f1468b565ae93ebd4b0ca766b326dbd074eR79) [[4]](diffhunk://#diff-5f4b8cff0691aab1dd8fdc2d8c495f1468b565ae93ebd4b0ca766b326dbd074eR89) [[5]](diffhunk://#diff-5f4b8cff0691aab1dd8fdc2d8c495f1468b565ae93ebd4b0ca766b326dbd074eR188-R204)
* Updated the workflow edit button in the completed workflows list: it is now disabled for users who only have read access to a shared workflow, and a tooltip explains the permission.
* Modified the workflow loading and saving logic to track and respect workflow ownership and user permissions, ensuring that only owners or users with write access can edit workflow names or content. [[1]](diffhunk://#diff-0d6420fdf423164ae7ffdb3f2f9f5247a1a8cbeb64dcb09674c84316ca85832dR69-R74) [[2]](diffhunk://#diff-0d6420fdf423164ae7ffdb3f2f9f5247a1a8cbeb64dcb09674c84316ca85832dR154-R165) [[3]](diffhunk://#diff-0d6420fdf423164ae7ffdb3f2f9f5247a1a8cbeb64dcb09674c84316ca85832dR421-R424) [[4]](diffhunk://#diff-0d6420fdf423164ae7ffdb3f2f9f5247a1a8cbeb64dcb09674c84316ca85832dL497-R515) [[5]](diffhunk://#diff-0d6420fdf423164ae7ffdb3f2f9f5247a1a8cbeb64dcb09674c84316ca85832dL684-R702) [[6]](diffhunk://#diff-dfeeb54466947b3738fbbe813d7d991639f0048bdc6c92509609d34a48618e90L12-R38) [[7]](diffhunk://#diff-90b4fcd42e6bc765cc80b3da0ec0dedb96f29b5e7e8e5b9590c8480998f91772L168-R168)

**User interface improvements:**

* Added a visual indicator (icon and tooltip) in the header to show when a workflow is shared and the current user is not the owner; disables the edit button for non-owners. [[1]](diffhunk://#diff-02fea483cf141aeaa0cca61eec49a3167d0d35237618e6c93a0e311b7c3c01a6R26) [[2]](diffhunk://#diff-02fea483cf141aeaa0cca61eec49a3167d0d35237618e6c93a0e311b7c3c01a6L42-R43) [[3]](diffhunk://#diff-02fea483cf141aeaa0cca61eec49a3167d0d35237618e6c93a0e311b7c3c01a6R169-R185) [[4]](diffhunk://#diff-4a11c006026276b13b22786b78fce3cf7cf7c1df8352a1202e78e2973274fe6fR124-R144)
* Improved the appearance of disabled action buttons and added a `.disabled` style for better accessibility and clarity.

**Keyboard and canvas enhancements:**

* Refactored keyboard shortcut handling to more reliably detect Ctrl/Cmd key presses across platforms. [[1]](diffhunk://#diff-ad266bf1a42a42400b54b7e5ce5c1fa700c9b332011ab3b5a919334f872335a0R31-R35) [[2]](diffhunk://#diff-ad266bf1a42a42400b54b7e5ce5c1fa700c9b332011ab3b5a919334f872335a0L53-R58)
* Made canvas grid lines thinner for a cleaner look.