### PR TITLE
chore: increase proxy timeout in Next.js config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+    experimental: {
+        proxyTimeout: 600,
+    },
     async rewrites() {
         const host_url =
             process.env.NEXT_PUBLIC_BACKEND_HOST || 'http://localhost';


### PR DESCRIPTION
Extend the experimental proxyTimeout setting to 600 seconds to allow longer backend response times, improving stability for slow or long-running requests.