### PR TITLE
fix: Increase proxy timeout in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
     experimental: {
-        proxyTimeout: 600,
+        proxyTimeout: 600000,
     },
     async rewrites() {
         const host_url =


### PR DESCRIPTION
Extend the proxyTimeout value from 600ms to 600000ms to prevent premature timeout errors during long-running proxy requests. This change improves stability for backend communications that require more time to respond.