### PR TITLE
fix: Update condition to display workflow usage details button

### DIFF
--- a/src/app/admin/components/workflows/AdminUserTokenDashboard.tsx
+++ b/src/app/admin/components/workflows/AdminUserTokenDashboard.tsx
@@ -671,7 +671,7 @@ const AdminUserTokenDashboard: React.FC = () => {
                                                     {user.workflow_usage &&
                                                         Object.keys(
                                                             user.workflow_usage,
-                                                        ).length > 1 && (
+                                                        ).length >= 1 && (
                                                             <button
                                                                 className={
                                                                     styles.detailsButton


### PR DESCRIPTION
This pull request makes a small update to the logic for displaying the details button in the `AdminUserTokenDashboard` component. The button will now appear if there is at least one workflow usage, rather than requiring more than one.

* Changed the condition to show the details button when `user.workflow_usage` has at least one entry, instead of more than one, in `AdminUserTokenDashboard.tsx`.